### PR TITLE
Override sizeThatFits to calculate sizes #10

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -123,6 +123,16 @@ public class ActiveLabel: UILabel {
         layoutManager.drawGlyphsForGlyphRange(range, atPoint: rect.origin)
     }
     
+    public override func sizeThatFits(size: CGSize) -> CGSize {
+        let currentSize = frame.size
+        defer {
+            textContainer.size = currentSize
+        }
+        
+        textContainer.size = size
+        return layoutManager.usedRectForTextContainer(textContainer).size
+    }
+    
     // MARK: - touch events
     func onTouch(gesture: UILongPressGestureRecognizer) {
         let location = gesture.locationInView(self)

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -124,7 +124,7 @@ public class ActiveLabel: UILabel {
     }
     
     public override func sizeThatFits(size: CGSize) -> CGSize {
-        let currentSize = frame.size
+        let currentSize = textContainer.size
         defer {
             textContainer.size = currentSize
         }


### PR DESCRIPTION
With `sizeThatFits`, `sizeToFit` comes for free too. 

However, there's still a size difference between the calculated size (through NSString and NSAttributedString means) and ActiveLabel. At least we now have a way to get the true size for ActiveLabel instances.