### PR TITLE
Events & Scroll conflict revisited

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -193,7 +193,6 @@ public class ActiveLabel: UILabel {
         
         let touchRecognizer = UILongPressGestureRecognizer(target: self, action: "onTouch:")
         touchRecognizer.minimumPressDuration = 0.00001
-        touchRecognizer.cancelsTouchesInView = false
         touchRecognizer.delegate = self
         addGestureRecognizer(touchRecognizer)
         
@@ -341,4 +340,11 @@ extension ActiveLabel: UIGestureRecognizerDelegate {
         return true
     }
     
+    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOfGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+    
+    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailByGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
 }


### PR DESCRIPTION
Hello it's me again :)

I noticed some unwanted behavior when integrating `ActiveLabel` in `UICollectionViewCell` instances. There were 2 problems:

- Tapping on a URL (or mention or hashtag) would call `urlTapHandler`, but would immediately trigger the `- collectionView:didSelectItemAtIndexPath:` delegate method - which can cause unwanted side effects - such as pushing a new ViewController etc.

- Starting touches on a URL (or mention or hashtag), then scrolling the collection view up / down would not stop `urlTapHandler` from firing when the touches end (because the touch is always on the label while scrolling), even when UICollectionView has `canCancelContentTouches` turned on. This is very unpleasant and different from how - say - `UIButton` works in a `UICollectionViewCell`.

I know the changes that caused these are related to #3 - To be fair same problems demonstrated in the video can also occur while using a `UIButton` in a TableView/CollectionView as well - when `canCancelContentTouches` and `delaysContentTouches` are set incorrectly.

I chose to solve these problems by overriding more `UIGestureRecognizerDelegate` methods - and have our `UILongPressGestureRecognizer` fail when the user scrolls.

I'm working on a single case scenario with `ActiveLabel`, so I'm not 100% sure (but pretty sure) if this will not break things for anyone. 

Please just let me know if you don't want to merge this, so I can switch to using my own fork in the project.

Thank you