### PR TITLE
Repeating keywords - better URL detection

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -251,15 +251,28 @@ import UIKit
     /// use regex check all link ranges
     private func parseTextAndExtractActiveElements(attrString: NSAttributedString) {
         let textString = attrString.string as NSString
-        for word in textString.componentsSeparatedByString(" ") {
+        let textLength = textString.length
+        var searchRange = NSMakeRange(0, textLength)
+        
+        for word in textString.componentsSeparatedByCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) {
             let element = activeElement(word)
+            
+            if case .None = element {
+                continue
+            }
+            
+            let elementRange = textString.rangeOfString(word, options: .LiteralSearch, range: searchRange)
+            
+            let startIndex: Int = elementRange.location + elementRange.length
+            searchRange = NSMakeRange(startIndex, textLength - startIndex)
+            
             switch element {
-            case .Mention(let userHandle) where mentionEnabled:
-                activeElements[.Mention]?.append((textString.rangeOfString("@\(userHandle)"), element))
-            case .Hashtag(let hashtag) where hashtagEnabled:
-                activeElements[.Hashtag]?.append((textString.rangeOfString("#\(hashtag)"), element))
-            case .URL(let url) where URLEnabled:
-                activeElements[.URL]?.append((textString.rangeOfString(url.absoluteString), element))
+            case .Mention where mentionEnabled:
+                activeElements[.Mention]?.append((elementRange, element))
+            case .Hashtag where hashtagEnabled:
+                activeElements[.Hashtag]?.append((elementRange, element))
+            case .URL where URLEnabled:
+                activeElements[.URL]?.append((elementRange, element))
             default: ()
             }
         }

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -262,9 +262,10 @@ import UIKit
             }
             
             let elementRange = textString.rangeOfString(word, options: .LiteralSearch, range: searchRange)
-            
-            let startIndex: Int = elementRange.location + elementRange.length
-            searchRange = NSMakeRange(startIndex, textLength - startIndex)
+            defer {
+                let startIndex = elementRange.location + elementRange.length
+                searchRange = NSMakeRange(startIndex, textLength - startIndex)
+            }
             
             switch element {
             case .Mention where mentionEnabled:

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -46,9 +46,9 @@ func activeElement(word: String) -> ActiveElement {
 }
 
 private func reduceRightToURL(str: String) -> NSURL? {
-    if let regex = try? NSRegularExpression(pattern: "(?i)https?://(?:www\\.)?\\S+(?:/|\\b)", options: [.CaseInsensitive]) {
+    if let urlDetector = try? NSDataDetector(types: NSTextCheckingType.Link.rawValue) {
         let nsStr = str as NSString
-        let results = regex.matchesInString(str, options: [], range: NSRange(location: 0, length: nsStr.length))
+        let results = urlDetector.matchesInString(str, options: .ReportCompletion, range: NSRange(location: 0, length: nsStr.length))
         if let result = results.map({ nsStr.substringWithRange($0.range) }).first, url = NSURL(string: result) {
             return url
         }

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -63,8 +63,8 @@ class ActiveTypeTests: XCTestCase {
         XCTAssertEqual(activeElement("http://www.google.com"), ActiveElement.URL(NSURL(string: "http://www.google.com")!))
         XCTAssertEqual(activeElement("https://www.google.com"), ActiveElement.URL(NSURL(string: "https://www.google.com")!))
         XCTAssertEqual(activeElement("https://www.google.com."), ActiveElement.URL(NSURL(string: "https://www.google.com")!))
-        XCTAssertEqual(activeElement("www.google.com"), ActiveElement.None)
-        XCTAssertEqual(activeElement("google.com"), ActiveElement.None)
+        XCTAssertEqual(activeElement("www.google.com"), ActiveElement.URL(NSURL(string: "www.google.com")!))
+        XCTAssertEqual(activeElement("google.com"), ActiveElement.URL(NSURL(string: "google.com")!))
     }
     
 }


### PR DESCRIPTION
This PR fixes #1 (repeating elements not recognized) by adjusting the substring search range after each match. 

It also ditches the regex in favor of `NSDataDetector` when finding URL's, I think it's better to trust Apple to do this better than a stackoverflow regex solution. As a bonus, URL's that look like `www.website.com` are now recognized as valid URL's.