### PR TITLE
ActiveLabelDelegate

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -16,7 +16,7 @@ public protocol ActiveLabelDelegate: class {
 @IBDesignable public class ActiveLabel: UILabel {
     
     // MARK: - public properties
-    weak var delegate: ActiveLabelDelegate?
+    public weak var delegate: ActiveLabelDelegate?
     
     @IBInspectable public var mentionEnabled: Bool = true {
         didSet {
@@ -369,8 +369,7 @@ public protocol ActiveLabelDelegate: class {
         super.touchesEnded(touches, withEvent: event)
     }
     
-    //MARK: ActiveLabel handler
-    
+    //MARK: - ActiveLabel handler
     private func didTapMention(username: String) {
         guard let mentionHandler = mentionTapHandler else {
             delegate?.didSelectText(username, type: .Mention)

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -9,9 +9,15 @@
 import Foundation
 import UIKit
 
+public protocol ActiveLabelDelegate: class {
+    func didSelectText(text: String, type: ActiveType)
+}
+
 @IBDesignable public class ActiveLabel: UILabel {
     
     // MARK: - public properties
+    weak var delegate: ActiveLabelDelegate?
+    
     @IBInspectable public var mentionEnabled: Bool = true {
         didSet {
             updateTextStorage()
@@ -155,9 +161,9 @@ import UIKit
             guard let selectedElement = selectedElement else { return avoidSuperCall }
             
             switch selectedElement.element {
-            case .Mention(let userHandle): mentionTapHandler?(userHandle)
-            case .Hashtag(let hashtag): hashtagTapHandler?(hashtag)
-            case .URL(let url): urlTapHandler?(url)
+            case .Mention(let userHandle): didTapMention(userHandle)
+            case .Hashtag(let hashtag): didTapHashtag(hashtag)
+            case .URL(let url): didTapStringURL(url)
             case .None: ()
             }
             
@@ -363,6 +369,31 @@ import UIKit
         super.touchesEnded(touches, withEvent: event)
     }
     
+    //MARK: ActiveLabel handler
+    
+    private func didTapMention(username: String) {
+        guard let mentionHandler = mentionTapHandler else {
+            delegate?.didSelectText(username, type: .Mention)
+            return
+        }
+        mentionHandler(username)
+    }
+    
+    private func didTapHashtag(hashtag: String) {
+        guard let hashtagHandler = hashtagTapHandler else {
+            delegate?.didSelectText(hashtag, type: .Hashtag)
+            return
+        }
+        hashtagHandler(hashtag)
+    }
+    
+    private func didTapStringURL(stringURL: String) {
+        guard let urlHandler = urlTapHandler, let url = NSURL(string: stringURL) else {
+            delegate?.didSelectText(stringURL, type: .URL)
+            return
+        }
+        urlHandler(url)
+    }
 }
 
 extension ActiveLabel: UIGestureRecognizerDelegate {

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -11,11 +11,11 @@ import Foundation
 enum ActiveElement {
     case Mention(String)
     case Hashtag(String)
-    case URL(NSURL)
+    case URL(String)
     case None
 }
 
-enum ActiveType {
+public enum ActiveType {
     case Mention
     case Hashtag
     case URL
@@ -45,12 +45,12 @@ func activeElement(word: String) -> ActiveElement {
     }
 }
 
-private func reduceRightToURL(str: String) -> NSURL? {
+private func reduceRightToURL(str: String) -> String? {
     if let urlDetector = try? NSDataDetector(types: NSTextCheckingType.Link.rawValue) {
         let nsStr = str as NSString
         let results = urlDetector.matchesInString(str, options: .ReportCompletion, range: NSRange(location: 0, length: nsStr.length))
-        if let result = results.map({ nsStr.substringWithRange($0.range) }).first, url = NSURL(string: result) {
-            return url
+        if let result = results.map({ nsStr.substringWithRange($0.range) }).first {
+            return result
         }
     }
     return nil

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -60,11 +60,11 @@ class ActiveTypeTests: XCTestCase {
     }
     
     func testURL() {
-        XCTAssertEqual(activeElement("http://www.google.com"), ActiveElement.URL(NSURL(string: "http://www.google.com")!))
-        XCTAssertEqual(activeElement("https://www.google.com"), ActiveElement.URL(NSURL(string: "https://www.google.com")!))
-        XCTAssertEqual(activeElement("https://www.google.com."), ActiveElement.URL(NSURL(string: "https://www.google.com")!))
-        XCTAssertEqual(activeElement("www.google.com"), ActiveElement.URL(NSURL(string: "www.google.com")!))
-        XCTAssertEqual(activeElement("google.com"), ActiveElement.URL(NSURL(string: "google.com")!))
+        XCTAssertEqual(activeElement("http://www.google.com"), ActiveElement.URL("http://www.google.com"))
+        XCTAssertEqual(activeElement("https://www.google.com"), ActiveElement.URL("https://www.google.com"))
+        XCTAssertEqual(activeElement("https://www.google.com."), ActiveElement.URL("https://www.google.com"))
+        XCTAssertEqual(activeElement("www.google.com"), ActiveElement.URL("www.google.com"))
+        XCTAssertEqual(activeElement("google.com"), ActiveElement.URL("google.com"))
     }
     
 }


### PR DESCRIPTION
#### :tophat: What? Why?
Adding another way of handling word taps.
With the current configuration, you have to manually add a handler for each label you create.

Using a delegate you can easily assign a delegate that is going to handle all the taps.

I changed `ActiveElement.URL(NSURL)` to `ActiveElement.URL(String)`, to be able to handle all the taps through the same `delegate`. Even with this change, the current public API has not changed.

#### :ghost: GIF
![](http://i.giphy.com/3o8doTsfXIV3ZTHA76.gif)