### PR TITLE
Replicating UILabel default vertical align

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -130,9 +130,10 @@ public protocol ActiveLabelDelegate: class {
         let range = NSRange(location: 0, length: textStorage.length)
         
         textContainer.size = rect.size
+        let newOrigin = textOrigin(inRect: rect)
         
-        layoutManager.drawBackgroundForGlyphRange(range, atPoint: rect.origin)
-        layoutManager.drawGlyphsForGlyphRange(range, atPoint: rect.origin)
+        layoutManager.drawBackgroundForGlyphRange(range, atPoint: newOrigin)
+        layoutManager.drawGlyphsForGlyphRange(range, atPoint: newOrigin)
     }
     
     public override func sizeThatFits(size: CGSize) -> CGSize {
@@ -229,6 +230,13 @@ public protocol ActiveLabelDelegate: class {
         textStorage.setAttributedString(mutAttrString)
         
         setNeedsDisplay()
+    }
+    
+    private func textOrigin(inRect rect: CGRect) -> CGPoint {
+        let usedRect = layoutManager.usedRectForTextContainer(textContainer)
+        let heightDiff = rect.height - usedRect.height
+        let glyphOriginY = heightDiff > 0 ? rect.origin.y + heightDiff/2 : rect.origin.y
+        return CGPoint(x: rect.origin.x, y: glyphOriginY)
     }
     
     /// add link attribute


### PR DESCRIPTION
#### :tophat: What? Why?
@rishi420 was working on the vertical align issue pointed out in #24 and in #30 .

The idea that the original PR suggested ( #32 ) was to add a property to check if the user wanted to vertically align the text inside the label. In my opinion, the alignment should be the same as the default for a native `UILabel`.

Taking this in account, what I've done is just that, by default now ActiveLabel has vertical alignment.

Closes #24 , closes #30 , closes #32

### Merry Christmas! :gift: 

#### :ghost: GIF
![](http://i.giphy.com/fgQ93ewM9gLG8.gif)