### PR TITLE
Correcting location when tapping on the label

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -192,6 +192,7 @@ public protocol ActiveLabelDelegate: class {
     private var urlTapHandler: ((NSURL) -> ())?
     
     private var selectedElement: (range: NSRange, element: ActiveElement)?
+    private var heightCorrection: CGFloat = 0
     private lazy var textStorage = NSTextStorage()
     private lazy var layoutManager = NSLayoutManager()
     private lazy var textContainer = NSTextContainer()
@@ -235,7 +236,8 @@ public protocol ActiveLabelDelegate: class {
     private func textOrigin(inRect rect: CGRect) -> CGPoint {
         let usedRect = layoutManager.usedRectForTextContainer(textContainer)
         let heightDiff = rect.height - usedRect.height
-        let glyphOriginY = heightDiff > 0 ? rect.origin.y + heightDiff/2 : rect.origin.y
+        heightCorrection = heightDiff/2
+        let glyphOriginY = heightDiff > 0 ? rect.origin.y + heightCorrection : rect.origin.y
         return CGPoint(x: rect.origin.x, y: glyphOriginY)
     }
     
@@ -347,13 +349,15 @@ public protocol ActiveLabelDelegate: class {
         guard textStorage.length > 0 else {
             return nil
         }
-        
+
+        var correctLocation = location
+        correctLocation.y -= heightCorrection
         let boundingRect = layoutManager.boundingRectForGlyphRange(NSRange(location: 0, length: textStorage.length), inTextContainer: textContainer)
-        guard boundingRect.contains(location) else {
+        guard boundingRect.contains(correctLocation) else {
             return nil
         }
         
-        let index = layoutManager.glyphIndexForPoint(location, inTextContainer: textContainer)
+        let index = layoutManager.glyphIndexForPoint(correctLocation, inTextContainer: textContainer)
         
         for element in activeElements.map({ $0.1 }).flatten() {
             if index >= element.range.location && index <= element.range.location + element.range.length {

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -235,9 +235,8 @@ public protocol ActiveLabelDelegate: class {
     
     private func textOrigin(inRect rect: CGRect) -> CGPoint {
         let usedRect = layoutManager.usedRectForTextContainer(textContainer)
-        let heightDiff = rect.height - usedRect.height
-        heightCorrection = heightDiff/2
-        let glyphOriginY = heightDiff > 0 ? rect.origin.y + heightCorrection : rect.origin.y
+        heightCorrection = (rect.height - usedRect.height)/2
+        let glyphOriginY = heightCorrection > 0 ? rect.origin.y + heightCorrection : rect.origin.y
         return CGPoint(x: rect.origin.x, y: glyphOriginY)
     }
     


### PR DESCRIPTION
#### :tophat: What? Why?
Since #35 , the location of the touch was not precise if the height of the label was bigger than the height of the text. 

Thanks @dimanicholson for your patience and your videos explaining the issue ( #38 )

The reason why it is happening is that `boundingRectForGlyphRange` is returning a CGRect on the origin, so it is only working now for labels that have the same size as the bounding rect of the text.

This PR introduces a correction to the tap location in order to avoid this problem on that situation.


#### :ghost: GIF
![](https://media.giphy.com/media/AAnIjZPUhrUM8/giphy.gif)

Closes #38 