### PR TITLE
Remove sizeThatFits - should fix most autolayout and sizing errors.

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -96,17 +96,7 @@ public protocol ActiveLabelDelegate: class {
         layoutManager.drawBackgroundForGlyphRange(range, atPoint: newOrigin)
         layoutManager.drawGlyphsForGlyphRange(range, atPoint: newOrigin)
     }
-    
-    public override func sizeThatFits(size: CGSize) -> CGSize {
-        let currentSize = textContainer.size
-        defer {
-            textContainer.size = currentSize
-        }
-        
-        textContainer.size = size
-        return layoutManager.usedRectForTextContainer(textContainer).size
-    }
-    
+
     // MARK: - touch events
     func onTouch(touch: UITouch) -> Bool {
         let location = touch.locationInView(self)


### PR DESCRIPTION
Although I was the one who originally put the override for `sizeThatFits` - I've recently realized that it no longer worked correctly due to the recent structural changes in `ActiveLabel`. Removing the override and relying on UILabel's own implementation seems to fix the issues. #45, #41 and #36 should see improvements with this one.