### PR TITLE
Removing dispatch_async to avoid unexpected effects

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -187,11 +187,9 @@ public protocol ActiveLabelDelegate: class {
             parseTextAndExtractActiveElements(mutAttrString)
         }
         
-        dispatch_async(dispatch_get_main_queue()) {
-            self.addLinkAttribute(mutAttrString)
-            self.textStorage.setAttributedString(mutAttrString)
-            self.setNeedsDisplay()
-        }
+        self.addLinkAttribute(mutAttrString)
+        self.textStorage.setAttributedString(mutAttrString)
+        self.setNeedsDisplay()
     }
     
     private func textOrigin(inRect rect: CGRect) -> CGPoint {


### PR DESCRIPTION
#### :tophat: What? Why?
As pointed out in the latest comments of #14 , the `dispatch_async` block was causing unintended effects. 

It is a consequence of #40. When trying to be more performant, I tried to do some of the execution asynchronously. That is leading to unexpected results, so I think it is correct to reduce a litter bit the performance, in benefit of consistency.

#### :ghost: GIF
![](http://i.giphy.com/MCOYBbJQz0Ksg.gif)