### PR TITLE
Bug/handle touch canceled

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -115,7 +115,7 @@ public protocol ActiveLabelDelegate: class {
                 updateAttributesWhenSelected(false)
                 selectedElement = nil
             }
-        case .Cancelled, .Ended:
+        case .Ended:
             guard let selectedElement = selectedElement else { return avoidSuperCall }
             
             switch selectedElement.element {
@@ -131,7 +131,8 @@ public protocol ActiveLabelDelegate: class {
                 self.selectedElement = nil
             }
             avoidSuperCall = true
-        default: ()
+        case .Cancelled, .Stationary:
+            break
         }
         
         return avoidSuperCall

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -131,7 +131,9 @@ public protocol ActiveLabelDelegate: class {
                 self.selectedElement = nil
             }
             avoidSuperCall = true
-        case .Cancelled, .Stationary:
+        case .Cancelled:
+            selectedElement = nil
+        case .Stationary:
             break
         }
         


### PR DESCRIPTION
#### :tophat: What? Why?
As pointed out in #43 , when adding an ActiveLabel in an scroll view, if you start scrolling at a point that there is a label, it is just going to treat it as a touch in the label, so it is triggering the associated action

With this PR, we are handling the canceled touch separately. :+1: 

#### :ghost: GIF
![](http://i.giphy.com/oZ0GeUMIXidtC.gif)

Closes #43