### PR TITLE
Batch customizations

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -77,13 +77,13 @@ public protocol ActiveLabelDelegate: class {
     // MARK: - init functions
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        
+        _customizing = false
         setupLabel()
     }
     
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        
+        _customizing = false
         setupLabel()
     }
     
@@ -95,6 +95,16 @@ public protocol ActiveLabelDelegate: class {
         
         layoutManager.drawBackgroundForGlyphRange(range, atPoint: newOrigin)
         layoutManager.drawGlyphsForGlyphRange(range, atPoint: newOrigin)
+    }
+    
+    
+    // MARK: - customzation
+    public func customize(block: (label: ActiveLabel) -> ()) -> ActiveLabel{
+        _customizing = true
+        block(label: self)
+        _customizing = false
+        updateTextStorage()
+        return self
     }
 
     // MARK: - touch events
@@ -141,6 +151,8 @@ public protocol ActiveLabelDelegate: class {
     }
     
     // MARK: - private properties
+    private var _customizing: Bool = true
+    
     private var mentionTapHandler: ((String) -> ())?
     private var hashtagTapHandler: ((String) -> ())?
     private var urlTapHandler: ((NSURL) -> ())?
@@ -165,6 +177,7 @@ public protocol ActiveLabelDelegate: class {
     }
     
     private func updateTextStorage(parseText parseText: Bool = true) {
+        if _customizing { return }
         // clean up previous active elements
         guard let attributedText = attributedText
             where attributedText.length > 0 else {

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -16,18 +16,20 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like this one: http://optonaut.co."
-        label.numberOfLines = 0
-        label.lineSpacing = 4
-        
-        label.textColor = UIColor(red: 102.0/255, green: 117.0/255, blue: 127.0/255, alpha: 1)
-        label.hashtagColor = UIColor(red: 85.0/255, green: 172.0/255, blue: 238.0/255, alpha: 1)
-        label.mentionColor = UIColor(red: 238.0/255, green: 85.0/255, blue: 96.0/255, alpha: 1)
-        label.URLColor = UIColor(red: 85.0/255, green: 238.0/255, blue: 151.0/255, alpha: 1)
-        
-        label.handleMentionTap { self.alert("Mention", message: $0) }
-        label.handleHashtagTap { self.alert("Hashtag", message: $0) }
-        label.handleURLTap { self.alert("URL", message: $0.description) }
+        label.customize { label in
+            label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like this one: http://optonaut.co."
+            label.numberOfLines = 0
+            label.lineSpacing = 4
+            
+            label.textColor = UIColor(red: 102.0/255, green: 117.0/255, blue: 127.0/255, alpha: 1)
+            label.hashtagColor = UIColor(red: 85.0/255, green: 172.0/255, blue: 238.0/255, alpha: 1)
+            label.mentionColor = UIColor(red: 238.0/255, green: 85.0/255, blue: 96.0/255, alpha: 1)
+            label.URLColor = UIColor(red: 85.0/255, green: 238.0/255, blue: 151.0/255, alpha: 1)
+            
+            label.handleMentionTap { self.alert("Mention", message: $0) }
+            label.handleHashtagTap { self.alert("Hashtag", message: $0) }
+            label.handleURLTap { self.alert("URL", message: $0.absoluteString) }
+        }
         
         label.frame = CGRect(x: 20, y: 40, width: view.frame.width - 40, height: 300)
         view.addSubview(label)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ label.handleHashtagTap { hashtag in
 }
 ```
 
+## Batched customization
+
+When using ActiveLabel, it is recommended to use the `customize(block:)` method to customize it. The reason is that ActiveLabel is reacting to each property that you set. So if you set 3 properties, the textContainer is refreshed 3 times.
+
+When using `customize(block:)`, you can group all the customizations on the label, that way ActiveLabel is only going to refresh the textContainer once.
+
+Example:
+
+```swift
+
+        label.customize { label in
+            label.text = "This is a post with #multiple #hashtags and a @userhandle."
+            label.textColor = UIColor(red: 102.0/255, green: 117.0/255, blue: 127.0/255, alpha: 1)
+            label.hashtagColor = UIColor(red: 85.0/255, green: 172.0/255, blue: 238.0/255, alpha: 1)
+            label.mentionColor = UIColor(red: 238.0/255, green: 85.0/255, blue: 96.0/255, alpha: 1)
+            label.URLColor = UIColor(red: 85.0/255, green: 238.0/255, blue: 151.0/255, alpha: 1)
+            label.handleMentionTap { self.alert("Mention", message: $0) }
+            label.handleHashtagTap { self.alert("Hashtag", message: $0) }
+            label.handleURLTap { self.alert("URL", message: $0.absoluteString) }
+        }
+
+
+```
+
+
 ## API
 
 ##### `mentionColor: UIColor = .blueColor()`


### PR DESCRIPTION
#### :tophat: What? Why?
When doing a full customisation of an ActiveLabel, each time the user changes a property, we are refreshing the textStorage with the latest change. When applying a lot of customisation to a label, that is reducing a lot the performance.

This PR is introducing a way to batch the customisations that you want to apply to a label inside a block, and the textStorage is only going to be refreshed when all of them are applied.

That should improve a lot the performance in complex labels added in table view cells

#### :ghost: GIF
![](https://m.popkey.co/aeb20b/J6d4v.gif)