### PR TITLE
Unset selected element when parsing text

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -174,6 +174,7 @@ public protocol ActiveLabelDelegate: class {
         let mutAttrString = addLineBreak(attributedText)
 
         if parseText {
+            selectedElement = nil
             for (type, _) in activeElements {
                 activeElements[type]?.removeAll()
             }


### PR DESCRIPTION
I had an issue where I was using this in a CollectionView and the cells were getting recycled as the result of tapping on a hashtag. When the selected attribute was dispatched 0.25 seconds later, the text had changed and caused an exception since the new text didn't contain the range of the old selected element. This makes it so the selected element gets cleared when the text is parsed so this does not happen.