### PR TITLE
Add mention and hashtag filtering

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -167,9 +167,9 @@ public protocol ActiveLabelDelegate: class {
     private var hashtagTapHandler: ((String) -> ())?
     private var urlTapHandler: ((NSURL) -> ())?
 
-    private var mentionFilterPredicate: ((String) -> Bool) = { _ in return false }
-    private var hashtagFilterPredicate: ((String) -> Bool) = { _ in return false }
-    
+    private var mentionFilterPredicate: ((String) -> Bool)?
+    private var hashtagFilterPredicate: ((String) -> Bool)?
+
     private var selectedElement: (range: NSRange, element: ActiveElement)?
     private var heightCorrection: CGFloat = 0
     private lazy var textStorage = NSTextStorage()
@@ -254,25 +254,13 @@ public protocol ActiveLabelDelegate: class {
         //URLS
         let urlElements = ActiveBuilder.createURLElements(fromText: textString, range: textRange)
         activeElements[.URL]?.appendContentsOf(urlElements)
-        
-        //HASHTAGS        
-        let hashtagElements = ActiveBuilder.createHashtagElements(fromText: textString, range: textRange).filter { (_, element: ActiveElement) in
 
-            switch element {
-                case .Hashtag(let tag): return hashtagFilterPredicate(tag)
-                default: return true
-            }
-        }
+        //HASHTAGS
+        let hashtagElements = ActiveBuilder.createHashtagElements(fromText: textString, range: textRange, filterPredicate: hashtagFilterPredicate)
         activeElements[.Hashtag]?.appendContentsOf(hashtagElements)
-        
-        //MENTIONS
-        let mentionElements = ActiveBuilder.createMentionElements(fromText: textString, range: textRange).filter { (_, element: ActiveElement) in
 
-            switch element {
-                case .Mention(let mention): return mentionFilterPredicate(mention)
-                default: return true
-            }
-        }
+        //MENTIONS
+        let mentionElements = ActiveBuilder.createMentionElements(fromText: textString, range: textRange, filterPredicate: mentionFilterPredicate)
         activeElements[.Mention]?.appendContentsOf(mentionElements)
     }
 

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -22,9 +22,11 @@ public enum ActiveType {
     case None
 }
 
+typealias ActiveFilterPredicate = (String -> Bool)
+
 struct ActiveBuilder {
     
-    static func createMentionElements(fromText text: String, range: NSRange) -> [(range: NSRange, element: ActiveElement)] {
+    static func createMentionElements(fromText text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [(range: NSRange, element: ActiveElement)] {
         let mentions = RegexParser.getMentions(fromText: text, range: range)
         let nsstring = text as NSString
         var elements: [(range: NSRange, element: ActiveElement)] = []
@@ -35,13 +37,16 @@ struct ActiveBuilder {
             if word.hasPrefix("@") {
                 word.removeAtIndex(word.startIndex)
             }
-            let element = ActiveElement.Mention(word)
-            elements.append((mention.range, element))
+
+            if filterPredicate?(word) ?? true {
+                let element = ActiveElement.Mention(word)
+                elements.append((mention.range, element))
+            }
         }
         return elements
     }
     
-    static func createHashtagElements(fromText text: String, range: NSRange) -> [(range: NSRange, element: ActiveElement)] {
+    static func createHashtagElements(fromText text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [(range: NSRange, element: ActiveElement)] {
         let hashtags = RegexParser.getHashtags(fromText: text, range: range)
         let nsstring = text as NSString
         var elements: [(range: NSRange, element: ActiveElement)] = []
@@ -52,8 +57,11 @@ struct ActiveBuilder {
             if word.hasPrefix("#") {
                 word.removeAtIndex(word.startIndex)
             }
-            let element = ActiveElement.Hashtag(word)
-            elements.append((hashtag.range, element))
+
+            if filterPredicate?(word) ?? true {
+                let element = ActiveElement.Hashtag(word)
+                elements.append((hashtag.range, element))
+            }
         }
         return elements
     }

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -205,5 +205,16 @@ class ActiveTypeTests: XCTestCase {
         label.text = "google.com"
         XCTAssertEqual(activeElements.count, 0)
     }
+
+    func testFiltering() {
+        label.text = "@user #tag"
+        XCTAssertEqual(activeElements.count, 2)
+
+        label.filterMention { $0 != "user" }
+        XCTAssertEqual(activeElements.count, 1)
+
+        label.filterHashtag { $0 != "tag" }
+        XCTAssertEqual(activeElements.count, 0)
+    }
     
 }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ label.handleHashtagTap { hashtag in print("\(hashtag) tapped") }
 label.handleURLTap { url in UIApplication.sharedApplication().openURL(url) }
 ```
 
+##### `filterHashtag: (String) -> Bool`
+
+```swift
+label.filterHashtag { hashtag in validHashtags.contains(hashtag) }
+```
+
+##### `filterMention: (String) -> Bool`
+
+```swift
+label.filterMention { mention in validMentions.contains(mention) }
+```
+
 ## Install (iOS 8+)
 
 ### Carthage


### PR DESCRIPTION
I needed this feature so that hashtags and mentions that were not actionable/valid in my app would not appear that way to my users (e.g. only @mentions for other valid users should appear to be tappable). I did not add url filtering because I could not think of a valid use for that. With the addition of the customize block a change like this should have little impact for those not using it.