### PR TITLE
Fixed wrong URL detection

### DIFF
--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -11,7 +11,7 @@ import Foundation
 struct RegexParser {
     
     static let urlPattern = "(^|[\\s.:;?\\-\\]<\\(])" +
-    "((https?://|www.|pic.)[-\\w;/?:@&=+$\\|\\_.!~*\\|'()\\[\\]%#,☺]+[\\w/#](\\(\\))?)" +
+    "((https?://|www\\.|pic\\.)[-\\w;/?:@&=+$\\|\\_.!~*\\|'()\\[\\]%#,☺]+[\\w/#](\\(\\))?)" +
     "(?=$|[\\s',\\|\\(\\).:;?\\-\\[\\]>\\)])"
     
     static let hashtagRegex = try? NSRegularExpression(pattern: "(?:^|\\s|$)#[\\p{L}0-9_]*", options: [.CaseInsensitive])

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -217,4 +217,15 @@ class ActiveTypeTests: XCTestCase {
         XCTAssertEqual(activeElements.count, 0)
     }
     
+    // test for issue https://github.com/optonaut/ActiveLabel.swift/issues/64
+    func testIssue64pic() {
+        label.text = "picfoo"
+        XCTAssertEqual(activeElements.count, 0)
+    }
+    
+    // test for issue https://github.com/optonaut/ActiveLabel.swift/issues/64
+    func testIssue64www() {
+        label.text = "wwwbar"
+        XCTAssertEqual(activeElements.count, 0)
+    }
 }


### PR DESCRIPTION
Hi!
I made a fix for issue https://github.com/optonaut/ActiveLabel.swift/issues/64.
There was missing escape character in "(https?://|www.|pic.)" where . treated as any character instead of 'dot'.

Closes #64