### PR TITLE
Call updateAttributesWhenSelected on Cancelled

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -152,6 +152,7 @@ public protocol ActiveLabelDelegate: class {
             }
             avoidSuperCall = true
         case .Cancelled:
+            updateAttributesWhenSelected(false)
             selectedElement = nil
         case .Stationary:
             break


### PR DESCRIPTION
When cancelled tap the link, keep in the selected state.
I think that it should be updated at the time of cancellation, what do you think?