### PR TITLE
Display text on uncustomized label

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -104,6 +104,11 @@ public protocol ActiveLabelDelegate: class {
         _customizing = false
         setupLabel()
     }
+
+    public override func awakeFromNib() {
+        super.awakeFromNib()
+        updateTextStorage()
+    }
     
     public override func drawTextInRect(rect: CGRect) {
         let range = NSRange(location: 0, length: textStorage.length)


### PR DESCRIPTION
When use the ActiveLabel using the Storyboard, not display text at uncustomized label.
This is because the `updateTextStorage` is not called even once.

I think this changes have small impact on the performance.
Do you have something workaround?

Thanks.