### PR TITLE
Fix linespacing setting

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -36,7 +36,7 @@ public protocol ActiveLabelDelegate: class {
     @IBInspectable public var URLSelectedColor: UIColor? {
         didSet { updateTextStorage(parseText: false) }
     }
-    @IBInspectable public var lineSpacing: Float? {
+    @IBInspectable public var lineSpacing: Float = 0 {
         didSet { updateTextStorage(parseText: false) }
     }
 
@@ -275,9 +275,7 @@ public protocol ActiveLabelDelegate: class {
         let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = NSLineBreakMode.ByWordWrapping
         paragraphStyle.alignment = textAlignment
-        if let lineSpacing = lineSpacing {
-            paragraphStyle.lineSpacing = CGFloat(lineSpacing)
-        }
+        paragraphStyle.lineSpacing = CGFloat(lineSpacing)
         
         attributes[NSParagraphStyleAttributeName] = paragraphStyle
         mutAttrString.setAttributes(attributes, range: range)


### PR DESCRIPTION
@IBInspectable is not support `Float?`.
 `didSet` is not called because they are not executed in runtime.

`lineSpacing` of `NSMutableParagraphStyle` default `0`, so it puts a `0` to the default value.
Now, the text that is correct linespace even on the Storyboard is reflected is displayed.

**Before**
<img width="899" alt="_2016-04-24_20_11_10" src="https://cloud.githubusercontent.com/assets/2995438/14767111/038118ea-0a59-11e6-9f7c-5eb84b9d0dda.png">

**After**
<img width="893" alt="_2016-04-24_20_11_34" src="https://cloud.githubusercontent.com/assets/2995438/14767113/0699892c-0a59-11e6-81e0-91e792f5f384.png">
