### PR TITLE
Add support numberOfLines and lineBreakMode

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -83,6 +83,14 @@ public protocol ActiveLabelDelegate: class {
     override public var textAlignment: NSTextAlignment {
         didSet { updateTextStorage(parseText: false)}
     }
+
+    public override var numberOfLines: Int {
+        didSet { textContainer.maximumNumberOfLines = numberOfLines }
+    }
+    
+    public override var lineBreakMode: NSLineBreakMode {
+        didSet { textContainer.lineBreakMode = lineBreakMode }
+    }
     
     // MARK: - init functions
     override public init(frame: CGRect) {
@@ -186,6 +194,8 @@ public protocol ActiveLabelDelegate: class {
         textStorage.addLayoutManager(layoutManager)
         layoutManager.addTextContainer(textContainer)
         textContainer.lineFragmentPadding = 0
+        textContainer.lineBreakMode = lineBreakMode
+        textContainer.maximumNumberOfLines = numberOfLines
         userInteractionEnabled = true
     }
     


### PR DESCRIPTION
Support UILabel properties
- numberOfLines
- lineBreakMode

**Before**
Not working `numberOfLines` and `lineBreakMode`
<img width="708" alt="_2016-04-24_22_38_04" src="https://cloud.githubusercontent.com/assets/2995438/14767948/1f5cddf0-0a6e-11e6-8004-5d59e8ba82a2.png">

**After**
Working `numberOfLines` and `lineBreakMode`
<img width="744" alt="2016-04-24 22 39 24" src="https://cloud.githubusercontent.com/assets/2995438/14767971/aa015b02-0a6e-11e6-9acd-ef1a455bfaf7.png">
<img width="676" alt="2016-04-24 22 46 38" src="https://cloud.githubusercontent.com/assets/2995438/14767972/b9f15c56-0a6e-11e6-8f4c-fb2c0fea992b.png">

Also it is reflected Storyboard.
<img width="864" alt="2016-04-24 22 49 43" src="https://cloud.githubusercontent.com/assets/2995438/14767981/fa87f89c-0a6e-11e6-9863-7dd3b15750b1.png">
