### PR TITLE
Fix auto layout size calculation

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -130,6 +130,14 @@ public protocol ActiveLabelDelegate: class {
         return self
     }
 
+    // MARK: - Auto layout
+    public override func intrinsicContentSize() -> CGSize {
+        let superSize = super.intrinsicContentSize()
+        textContainer.size = CGSize(width: superSize.width, height: CGFloat.max)
+        let size = layoutManager.usedRectForTextContainer(textContainer)
+        return CGSize(width: size.width, height: ceil(size.height))
+    }
+    
     // MARK: - touch events
     func onTouch(touch: UITouch) -> Bool {
         let location = touch.locationInView(self)


### PR DESCRIPTION
Size calculation of AutoLayout has shifted to when using the ActiveLabel of customized state in the Storyboard.
So it has been changed to return the correct size using the `layoutManager`

**Before**
<img width="918" alt="2016-05-01 21 34 25" src="https://cloud.githubusercontent.com/assets/2995438/14941848/77d6ea8a-0fe5-11e6-82c7-6e41f1b95050.png">

**After**
<img width="891" alt="2016-05-01 21 34 45" src="https://cloud.githubusercontent.com/assets/2995438/14941851/925f2c0a-0fe5-11e6-9787-4d73d3fcf9ca.png">

## Fix
- Fixes #36 
- Fixes #45 
- Fixes #67

## Check
- Check if not destroy the existing implementation and performance
 - [x] To use the ActiveLabel in code base (AutoSizing)
 - [x] To use the ActiveLabel in code base (AutoLayout)
 - [x] To use the ActiveLabel in Storyboard base (AutoSizing)
 - [x] To use the ActiveLabel in Storyboard base (AutoLayout)
 - [x] Use custom fonts