### PR TITLE
Fix: obscure auto-layout bug that would truncate text

### DIFF
--- a/ActiveLabel.podspec
+++ b/ActiveLabel.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 	s.homepage    = 'https://github.com/optonaut/ActiveLabel.swift'
 	s.license     = { :type => 'MIT', :file => 'LICENSE' }
 	s.platform    = :ios, '8.0'
-	s.source      = { :git => 'https://github.com/nxtstep/ActiveLabel.swift.git', :tag => s.version.to_s }
+	s.source      = { :git => 'https://github.com/optonaut/ActiveLabel.swift.git', :tag => s.version.to_s }
 	s.summary     = 'UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://) written in Swift'
 	s.description = <<-DESC
 		UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://) written in Swift

--- a/ActiveLabel.podspec
+++ b/ActiveLabel.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
 	s.name    = 'ActiveLabel'
-	s.version = '0.5.0'
+	s.version = '0.5.1'
 
 	s.author      = { 'Optonaut' => 'hello@optonaut.co' }
 	s.homepage    = 'https://github.com/optonaut/ActiveLabel.swift'
 	s.license     = { :type => 'MIT', :file => 'LICENSE' }
 	s.platform    = :ios, '8.0'
-	s.source      = { :git => 'https://github.com/optonaut/ActiveLabel.swift.git', :tag => s.version.to_s }
+	s.source      = { :git => 'https://github.com/nxtstep/ActiveLabel.swift.git', :tag => s.version.to_s }
 	s.summary     = 'UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://) written in Swift'
 	s.description = <<-DESC
 		UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://) written in Swift

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -135,7 +135,7 @@ public protocol ActiveLabelDelegate: class {
         let superSize = super.intrinsicContentSize()
         textContainer.size = CGSize(width: superSize.width, height: CGFloat.max)
         let size = layoutManager.usedRectForTextContainer(textContainer)
-        return CGSize(width: size.width, height: ceil(size.height))
+        return CGSize(width: ceil(size.width), height: ceil(size.height))
     }
     
     // MARK: - touch events


### PR DESCRIPTION
Rounding up the width value (like height) while calculating the intrinsicContentSize fixes text truncation or multi-line layout in some edge cases when using Auto-layout constraints


**Before**  
<img src="https://cloud.githubusercontent.com/assets/550169/15961431/0921b5cc-2f05-11e6-8190-8dc2cb8d7563.jpg" width="300">
<img src="https://cloud.githubusercontent.com/assets/550169/15961430/0920791e-2f05-11e6-94c8-efc5e35e4940.jpg" width="300">

**After**
<img src="https://cloud.githubusercontent.com/assets/550169/15961429/09200c72-2f05-11e6-82eb-23db045ade9e.jpg" width="300">
<img src="https://cloud.githubusercontent.com/assets/550169/15961428/09200b32-2f05-11e6-9975-44f10285b436.jpg" width="300">
