### PR TITLE
Allow custom patterns highlighting via regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: objective-c
 
 xcode_project: ActiveLabel.xcodeproj
 xcode_scheme: ActiveLabel
-osx_image: xcode7
-xcode_sdk: iphonesimulator9.0
+osx_image: xcode7.3
+xcode_sdk: iphonesimulator9.3

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -213,7 +213,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     private lazy var textStorage = NSTextStorage()
     private lazy var layoutManager = NSLayoutManager()
     private lazy var textContainer = NSTextContainer()
-    private lazy var activeElements = [ActiveType: [ElementTuple]]()
+    lazy var activeElements = [ActiveType: [ElementTuple]]()
 
     // MARK: - helper functions
     private func setupLabel() {
@@ -301,13 +301,13 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
 
         //HASHTAGS
         if enabledTypes.contains(.Hashtag) {
-            let hashtagElements = ActiveBuilder.createElements(.Hashtag, from: textString, range: textRange, filterPredicate: nil)
+            let hashtagElements = ActiveBuilder.createElements(.Hashtag, from: textString, range: textRange, filterPredicate: hashtagFilterPredicate)
             activeElements[.Hashtag] = hashtagElements
         }
 
         //MENTIONS
         if enabledTypes.contains(.Mention) {
-            let mentionElements = ActiveBuilder.createElements(.Mention, from: textString, range: textRange, filterPredicate: nil)
+            let mentionElements = ActiveBuilder.createElements(.Mention, from: textString, range: textRange, filterPredicate: mentionFilterPredicate)
             activeElements[.Mention] = mentionElements
         }
 

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -292,30 +292,16 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
         let textString = attrString.string
         let textLength = textString.utf16.count
         let textRange = NSRange(location: 0, length: textLength)
-        
-        //URLS
-        if enabledTypes.contains(.URL) {
-            let urlElements = ActiveBuilder.createElements(.URL, from: textString, range: textRange, filterPredicate: nil)
-            activeElements[.URL] = urlElements
-        }
 
-        //HASHTAGS
-        if enabledTypes.contains(.Hashtag) {
-            let hashtagElements = ActiveBuilder.createElements(.Hashtag, from: textString, range: textRange, filterPredicate: hashtagFilterPredicate)
-            activeElements[.Hashtag] = hashtagElements
-        }
-
-        //MENTIONS
-        if enabledTypes.contains(.Mention) {
-            let mentionElements = ActiveBuilder.createElements(.Mention, from: textString, range: textRange, filterPredicate: mentionFilterPredicate)
-            activeElements[.Mention] = mentionElements
-        }
-
-        //CUSTOM
-        let customTypes = enabledTypes.filter { $0.isCustom }
-        for customType in customTypes {
-            let elements = ActiveBuilder.createElements(customType, from: textString, range: textRange, filterPredicate: nil)
-            activeElements[customType] = elements
+        for type in enabledTypes {
+            var filter: ((String) -> Bool)? = nil
+            if type == .Mention {
+                filter = mentionFilterPredicate
+            } else if type == .Hashtag {
+                filter = hashtagFilterPredicate
+            }
+            let hashtagElements = ActiveBuilder.createElements(type, from: textString, range: textRange, filterPredicate: filter)
+            activeElements[type] = hashtagElements
         }
     }
 

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -13,10 +13,14 @@ public protocol ActiveLabelDelegate: class {
     func didSelectText(text: String, type: ActiveType)
 }
 
+typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveType)
+
 @IBDesignable public class ActiveLabel: UILabel {
     
     // MARK: - public properties
     public weak var delegate: ActiveLabelDelegate?
+
+    public var enabledTypes: [ActiveType] = [.Mention, .Hashtag, .URL]
     
     @IBInspectable public var mentionColor: UIColor = .blueColor() {
         didSet { updateTextStorage(parseText: false) }
@@ -36,6 +40,12 @@ public protocol ActiveLabelDelegate: class {
     @IBInspectable public var URLSelectedColor: UIColor? {
         didSet { updateTextStorage(parseText: false) }
     }
+    public var customColor: [ActiveType : UIColor] = [:] {
+        didSet { updateTextStorage(parseText: false) }
+    }
+    public var customSelectedColor: [ActiveType : UIColor] = [:] {
+        didSet { updateTextStorage(parseText: false) }
+    }
     @IBInspectable public var lineSpacing: Float = 0 {
         didSet { updateTextStorage(parseText: false) }
     }
@@ -51,6 +61,10 @@ public protocol ActiveLabelDelegate: class {
     
     public func handleURLTap(handler: (NSURL) -> ()) {
         urlTapHandler = handler
+    }
+
+    public func handleCustomTap(for type: ActiveType, handler: (String) -> ()) {
+        customTapHandlers[type] = handler
     }
 
     public func filterMention(predicate: (String) -> Bool) {
@@ -122,7 +136,7 @@ public protocol ActiveLabelDelegate: class {
     
     
     // MARK: - customzation
-    public func customize(block: (label: ActiveLabel) -> ()) -> ActiveLabel{
+    public func customize(block: (label: ActiveLabel) -> ()) -> ActiveLabel {
         _customizing = true
         block(label: self)
         _customizing = false
@@ -163,7 +177,7 @@ public protocol ActiveLabelDelegate: class {
             case .Mention(let userHandle): didTapMention(userHandle)
             case .Hashtag(let hashtag): didTapHashtag(hashtag)
             case .URL(let url): didTapStringURL(url)
-            case .None: ()
+            case .Custom(let element): didTap(element, for: selectedElement.type)
             }
             
             let when = dispatch_time(DISPATCH_TIME_NOW, Int64(0.25 * Double(NSEC_PER_SEC)))
@@ -184,25 +198,23 @@ public protocol ActiveLabelDelegate: class {
     
     // MARK: - private properties
     private var _customizing: Bool = true
+    private var defaultCustomColor: UIColor = .blackColor()
     
     private var mentionTapHandler: ((String) -> ())?
     private var hashtagTapHandler: ((String) -> ())?
     private var urlTapHandler: ((NSURL) -> ())?
+    private var customTapHandlers: [ActiveType : ((String) -> ())] = [:]
 
     private var mentionFilterPredicate: ((String) -> Bool)?
     private var hashtagFilterPredicate: ((String) -> Bool)?
 
-    private var selectedElement: (range: NSRange, element: ActiveElement)?
+    private var selectedElement: ElementTuple?
     private var heightCorrection: CGFloat = 0
     private lazy var textStorage = NSTextStorage()
     private lazy var layoutManager = NSLayoutManager()
     private lazy var textContainer = NSTextContainer()
-    internal lazy var activeElements: [ActiveType: [(range: NSRange, element: ActiveElement)]] = [
-        .Mention: [],
-        .Hashtag: [],
-        .URL: [],
-    ]
-    
+    private lazy var activeElements = [ActiveType: [ElementTuple]]()
+
     // MARK: - helper functions
     private func setupLabel() {
         textStorage.addLayoutManager(layoutManager)
@@ -230,9 +242,9 @@ public protocol ActiveLabelDelegate: class {
             parseTextAndExtractActiveElements(mutAttrString)
         }
         
-        self.addLinkAttribute(mutAttrString)
-        self.textStorage.setAttributedString(mutAttrString)
-        self.setNeedsDisplay()
+        addLinkAttribute(mutAttrString)
+        textStorage.setAttributedString(mutAttrString)
+        setNeedsDisplay()
     }
 
     private func clearActiveElements() {
@@ -266,7 +278,7 @@ public protocol ActiveLabelDelegate: class {
             case .Mention: attributes[NSForegroundColorAttributeName] = mentionColor
             case .Hashtag: attributes[NSForegroundColorAttributeName] = hashtagColor
             case .URL: attributes[NSForegroundColorAttributeName] = URLColor
-            case .None: ()
+            case .Custom: attributes[NSForegroundColorAttributeName] = customColor[type] ?? defaultCustomColor
             }
             
             for element in elements {
@@ -282,16 +294,29 @@ public protocol ActiveLabelDelegate: class {
         let textRange = NSRange(location: 0, length: textLength)
         
         //URLS
-        let urlElements = ActiveBuilder.createURLElements(fromText: textString, range: textRange)
-        activeElements[.URL]?.appendContentsOf(urlElements)
+        if enabledTypes.contains(.URL) {
+            let urlElements = ActiveBuilder.createElements(.URL, from: textString, range: textRange, filterPredicate: nil)
+            activeElements[.URL] = urlElements
+        }
 
         //HASHTAGS
-        let hashtagElements = ActiveBuilder.createHashtagElements(fromText: textString, range: textRange, filterPredicate: hashtagFilterPredicate)
-        activeElements[.Hashtag]?.appendContentsOf(hashtagElements)
+        if enabledTypes.contains(.Hashtag) {
+            let hashtagElements = ActiveBuilder.createElements(.Hashtag, from: textString, range: textRange, filterPredicate: nil)
+            activeElements[.Hashtag] = hashtagElements
+        }
 
         //MENTIONS
-        let mentionElements = ActiveBuilder.createMentionElements(fromText: textString, range: textRange, filterPredicate: mentionFilterPredicate)
-        activeElements[.Mention]?.appendContentsOf(mentionElements)
+        if enabledTypes.contains(.Mention) {
+            let mentionElements = ActiveBuilder.createElements(.Mention, from: textString, range: textRange, filterPredicate: nil)
+            activeElements[.Mention] = mentionElements
+        }
+
+        //CUSTOM
+        let customTypes = enabledTypes.filter { $0.isCustom }
+        for customType in customTypes {
+            let elements = ActiveBuilder.createElements(customType, from: textString, range: textRange, filterPredicate: nil)
+            activeElements[customType] = elements
+        }
     }
 
     
@@ -319,20 +344,28 @@ public protocol ActiveLabelDelegate: class {
         }
         
         var attributes = textStorage.attributesAtIndex(0, effectiveRange: nil)
+        let type = selectedElement.type
+
         if isSelected {
-            switch selectedElement.element {
-            case .Mention(_): attributes[NSForegroundColorAttributeName] = mentionSelectedColor ?? mentionColor
-            case .Hashtag(_): attributes[NSForegroundColorAttributeName] = hashtagSelectedColor ?? hashtagColor
-            case .URL(_): attributes[NSForegroundColorAttributeName] = URLSelectedColor ?? URLColor
-            case .None: ()
+            let selectedColor: UIColor
+            switch type {
+            case .Mention: selectedColor = mentionSelectedColor ?? mentionColor
+            case .Hashtag: selectedColor = hashtagSelectedColor ?? hashtagColor
+            case .URL: selectedColor = URLSelectedColor ?? URLColor
+            case .Custom:
+                let possibleSelectedColor = customSelectedColor[selectedElement.type] ?? customColor[selectedElement.type]
+                selectedColor = possibleSelectedColor ?? defaultCustomColor
             }
+            attributes[NSForegroundColorAttributeName] = selectedColor
         } else {
-            switch selectedElement.element {
-            case .Mention(_): attributes[NSForegroundColorAttributeName] = mentionColor
-            case .Hashtag(_): attributes[NSForegroundColorAttributeName] = hashtagColor
-            case .URL(_): attributes[NSForegroundColorAttributeName] = URLColor
-            case .None: ()
+            let unselectedColor: UIColor
+            switch type {
+            case .Mention: unselectedColor = mentionColor
+            case .Hashtag: unselectedColor = hashtagColor
+            case .URL: unselectedColor = URLColor
+            case .Custom: unselectedColor = customColor[selectedElement.type] ?? defaultCustomColor
             }
+            attributes[NSForegroundColorAttributeName] = unselectedColor
         }
         
         textStorage.addAttributes(attributes, range: selectedElement.range)
@@ -340,7 +373,7 @@ public protocol ActiveLabelDelegate: class {
         setNeedsDisplay()
     }
     
-    private func elementAtLocation(location: CGPoint) -> (range: NSRange, element: ActiveElement)? {
+    private func elementAtLocation(location: CGPoint) -> ElementTuple? {
         guard textStorage.length > 0 else {
             return nil
         }
@@ -412,6 +445,14 @@ public protocol ActiveLabelDelegate: class {
             return
         }
         urlHandler(url)
+    }
+
+    private func didTap(element: String, for type: ActiveType) {
+        guard let elementHandler = customTapHandlers[type] else {
+            delegate?.didSelectText(element, type: type)
+            return
+        }
+        elementHandler(element)
     }
 }
 

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -91,8 +91,10 @@ struct ActiveBuilder {
         for match in matches where match.range.length > 2 {
             let word = nsstring.substringWithRange(match.range)
                 .stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-            let element = ActiveElement.create(with: type, text: word)
-            elements.append((match.range, element, type))
+            if filterPredicate?(word) ?? true {
+                let element = ActiveElement.create(with: type, text: word)
+                elements.append((match.range, element, type))
+            }
         }
         return elements
     }
@@ -109,6 +111,9 @@ struct ActiveBuilder {
             let range = NSRange(location: match.range.location + 1, length: match.range.length - 1)
             var word = nsstring.substringWithRange(range)
             if word.hasPrefix("@") {
+                word.removeAtIndex(word.startIndex)
+            }
+            else if word.hasPrefix("#") {
                 word.removeAtIndex(word.startIndex)
             }
 

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -30,12 +30,6 @@ public enum ActiveType {
     case URL
     case Custom(pattern: String)
 
-    var isCustom: Bool {
-        if case .Custom = self {
-            return true
-        }
-        return false
-    }
     var pattern: String {
         switch self {
         case .Mention: return RegexParser.mentionPattern

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -12,71 +12,112 @@ enum ActiveElement {
     case Mention(String)
     case Hashtag(String)
     case URL(String)
-    case None
+    case Custom(String)
+
+    static func create(with activeType: ActiveType, text: String) -> ActiveElement {
+        switch activeType {
+        case .Mention: return Mention(text)
+        case .Hashtag: return Hashtag(text)
+        case .URL: return URL(text)
+        case .Custom: return Custom(text)
+        }
+    }
 }
 
 public enum ActiveType {
     case Mention
     case Hashtag
     case URL
-    case None
+    case Custom(pattern: String)
+
+    var isCustom: Bool {
+        if case .Custom = self {
+            return true
+        }
+        return false
+    }
+    var pattern: String {
+        switch self {
+        case .Mention: return RegexParser.mentionPattern
+        case .Hashtag: return RegexParser.hashtagPattern
+        case .URL: return RegexParser.urlPattern
+        case .Custom(let regex): return regex
+        }
+    }
+}
+
+extension ActiveType: Hashable, Equatable {
+    public var hashValue: Int {
+        switch self {
+        case .Mention: return -1
+        case .Hashtag: return -2
+        case .URL: return -3
+        case .Custom(let regex): return regex.hashValue
+        }
+    }
+}
+
+public func ==(lhs: ActiveType, rhs: ActiveType) -> Bool {
+    switch (lhs, rhs) {
+    case (.Mention, .Mention): return true
+    case (.Hashtag, .Hashtag): return true
+    case (.URL, .URL): return true
+    case (.Custom(let pattern1), .Custom(let pattern2)): return pattern1 == pattern2
+    default: return false
+    }
 }
 
 typealias ActiveFilterPredicate = (String -> Bool)
 
 struct ActiveBuilder {
-    
-    static func createMentionElements(fromText text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [(range: NSRange, element: ActiveElement)] {
-        let mentions = RegexParser.getMentions(fromText: text, range: range)
+
+    static func createElements(type: ActiveType, from text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
+        switch type {
+        case .Mention, .Hashtag:
+            return createElementsIgnoringFirstCharacter(from: text, for: type, range: range, filterPredicate: filterPredicate)
+        case .URL, .Custom:
+            return createElements(from: text, for: type, range: range, filterPredicate: filterPredicate)
+        }
+    }
+
+    private static func createElements(from text: String,
+                                    for type: ActiveType,
+                                          range: NSRange,
+                                          filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
+        let matches = RegexParser.getElements(from: text, with: type.pattern, range: range)
         let nsstring = text as NSString
-        var elements: [(range: NSRange, element: ActiveElement)] = []
-        
-        for mention in mentions where mention.range.length > 2 {
-            let range = NSRange(location: mention.range.location + 1, length: mention.range.length - 1)
+        var elements: [ElementTuple] = []
+
+        for match in matches where match.range.length > 2 {
+            let word = nsstring.substringWithRange(match.range)
+                .stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+            let element = ActiveElement.create(with: type, text: word)
+            elements.append((match.range, element, type))
+        }
+        return elements
+    }
+
+    private static func createElementsIgnoringFirstCharacter(from text: String,
+                                                                  for type: ActiveType,
+                                                                range: NSRange,
+                                                                filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
+        let matches = RegexParser.getElements(from: text, with: type.pattern, range: range)
+        let nsstring = text as NSString
+        var elements: [ElementTuple] = []
+
+        for match in matches where match.range.length > 2 {
+            let range = NSRange(location: match.range.location + 1, length: match.range.length - 1)
             var word = nsstring.substringWithRange(range)
             if word.hasPrefix("@") {
                 word.removeAtIndex(word.startIndex)
             }
 
             if filterPredicate?(word) ?? true {
-                let element = ActiveElement.Mention(word)
-                elements.append((mention.range, element))
+                let element = ActiveElement.create(with: type, text: word)
+                elements.append((match.range, element, type))
             }
         }
         return elements
-    }
-    
-    static func createHashtagElements(fromText text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [(range: NSRange, element: ActiveElement)] {
-        let hashtags = RegexParser.getHashtags(fromText: text, range: range)
-        let nsstring = text as NSString
-        var elements: [(range: NSRange, element: ActiveElement)] = []
         
-        for hashtag in hashtags where hashtag.range.length > 2 {
-            let range = NSRange(location: hashtag.range.location + 1, length: hashtag.range.length - 1)
-            var word = nsstring.substringWithRange(range)
-            if word.hasPrefix("#") {
-                word.removeAtIndex(word.startIndex)
-            }
-
-            if filterPredicate?(word) ?? true {
-                let element = ActiveElement.Hashtag(word)
-                elements.append((hashtag.range, element))
-            }
-        }
-        return elements
-    }
-    
-    static func createURLElements(fromText text: String, range: NSRange) -> [(range: NSRange, element: ActiveElement)] {
-        let urls = RegexParser.getURLs(fromText: text, range: range)
-        let nsstring = text as NSString
-        var elements: [(range: NSRange, element: ActiveElement)] = []
-        
-        for url in urls where url.range.length > 2 {
-            let word = nsstring.substringWithRange(url.range)
-                .stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-            let element = ActiveElement.URL(word)
-            elements.append((url.range, element))
-        }
-        return elements
     }
 }

--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -9,28 +9,16 @@
 import Foundation
 
 struct RegexParser {
-    
+
+    static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"
+    static let mentionPattern = "(?:^|\\s|$|[.])@[\\p{L}0-9_]*"
     static let urlPattern = "(^|[\\s.:;?\\-\\]<\\(])" +
-    "((https?://|www\\.|pic\\.)[-\\w;/?:@&=+$\\|\\_.!~*\\|'()\\[\\]%#,☺]+[\\w/#](\\(\\))?)" +
+        "((https?://|www\\.|pic\\.)[-\\w;/?:@&=+$\\|\\_.!~*\\|'()\\[\\]%#,☺]+[\\w/#](\\(\\))?)" +
     "(?=$|[\\s',\\|\\(\\).:;?\\-\\[\\]>\\)])"
-    
-    static let hashtagRegex = try? NSRegularExpression(pattern: "(?:^|\\s|$)#[\\p{L}0-9_]*", options: [.CaseInsensitive])
-    static let mentionRegex = try? NSRegularExpression(pattern: "(?:^|\\s|$|[.])@[\\p{L}0-9_]*", options: [.CaseInsensitive]);
-    static let urlDetector = try? NSRegularExpression(pattern: urlPattern, options: [.CaseInsensitive])
-    
-    static func getMentions(fromText text: String, range: NSRange) -> [NSTextCheckingResult] {
-        guard let mentionRegex = mentionRegex else { return [] }
-        return mentionRegex.matchesInString(text, options: [], range: range)
+
+
+    static func getElements(from text: String, with pattern: String, range: NSRange) -> [NSTextCheckingResult]{
+        guard let elementRegex = try? NSRegularExpression(pattern: pattern, options: [.CaseInsensitive]) else { return [] }
+        return elementRegex.matchesInString(text, options: [], range: range)
     }
-    
-    static func getHashtags(fromText text: String, range: NSRange) -> [NSTextCheckingResult] {
-        guard let hashtagRegex = hashtagRegex else { return [] }
-        return hashtagRegex.matchesInString(text, options: [], range: range)
-    }
-    
-    static func getURLs(fromText text: String, range: NSRange) -> [NSTextCheckingResult] {
-        guard let urlDetector = urlDetector else { return [] }
-        return urlDetector.matchesInString(text, options: [], range: range)
-    }
-    
 }

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -15,9 +15,16 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        let customType = ActiveType.Custom(pattern: "\\sare\\b") //Looks for "are"
+        let customType2 = ActiveType.Custom(pattern: "\\sit\\b") //Looks for "it"
+
+        label.enabledTypes.append(customType)
+        label.enabledTypes.append(customType2)
+
         label.customize { label in
-            label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like this one: http://optonaut.co."
+            label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like" +
+            " this one: http://optonaut.co. Now it also supports custom patterns -> are"
             label.numberOfLines = 0
             label.lineSpacing = 4
             
@@ -30,8 +37,18 @@ class ViewController: UIViewController {
             label.handleMentionTap { self.alert("Mention", message: $0) }
             label.handleHashtagTap { self.alert("Hashtag", message: $0) }
             label.handleURLTap { self.alert("URL", message: $0.absoluteString) }
+
+            //Custom types
+
+            label.customColor[customType] = UIColor.purpleColor()
+            label.customSelectedColor[customType] = UIColor.greenColor()
+            label.customColor[customType2] = UIColor.magentaColor()
+            label.customSelectedColor[customType2] = UIColor.greenColor()
+
+            label.handleCustomTap(for: customType) { self.alert("Custom type", message: $0) }
+            label.handleCustomTap(for: customType2) { self.alert("Custom type", message: $0) }
         }
-        
+
         label.frame = CGRect(x: 20, y: 40, width: view.frame.width - 40, height: 300)
         view.addSubview(label)
         

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # ActiveLabel.swift [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Build Status](https://travis-ci.org/optonaut/ActiveLabel.swift.svg)](https://travis-ci.org/optonaut/ActiveLabel.swift)
 
-UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://) written in Swift
+UILabel drop-in replacement supporting Hashtags (#), Mentions (@), URLs (http://) and custom regex patterns, written in Swift
 
 ## Features
 
 * Swift 2+
-* Support for **Hashtags, Mentions and Links**
+* Default support for **Hashtags, Mentions, Links**
+* Support for **custom types** via regex
+* Ability to enable highlighting only for the desired types
 * Super easy to use and lightweight
 * Works as `UILabel` drop-in replacement
 * Well tested and documented
@@ -20,12 +22,38 @@ import ActiveLabel
 let label = ActiveLabel()
 
 label.numberOfLines = 0
+label.enabledTypes = [.Mention, .Hashtag, .URL]
 label.text = "This is a post with #hashtags and a @userhandle."
 label.textColor = .blackColor()
 label.handleHashtagTap { hashtag in
   print("Success. You just tapped the \(hashtag) hashtag")
 }
 ```
+
+## Custom types
+
+```swift
+    let customType = ActiveType.Custom(pattern: "\\swith\\b") //Regex that looks for "with"
+    label.enabledTypes = [.Mention, .Hashtag, .URL, customType]
+    
+    label.customColor[customType] = UIColor.purpleColor()
+    label.customSelectedColor[customType] = UIColor.greenColor()
+    
+    label.handleCustomTap(for: customType) { element in 
+        print("Custom type tapped: \(element)") 
+    }
+```
+
+## Enable/disable highlighting
+
+By default, an ActiveLabel instance has the following configuration
+
+```swift
+    label.enabledTypes = [.Mention, .Hashtag, .URL]
+```
+
+But feel free to enable/disable to fit your requirements
+
 
 ## Batched customization
 
@@ -60,6 +88,8 @@ Example:
 ##### `hashtagSelectedColor: UIColor?`
 ##### `URLColor: UIColor = .blueColor()`
 ##### `URLSelectedColor: UIColor?`
+#### `customColor: [ActiveType : UIColor]`
+#### `customSelectedColor: [ActiveType : UIColor]`
 ##### `lineSpacing: Float?`
 
 ##### `handleMentionTap: (String) -> ()`
@@ -78,6 +108,12 @@ label.handleHashtagTap { hashtag in print("\(hashtag) tapped") }
 
 ```swift
 label.handleURLTap { url in UIApplication.sharedApplication().openURL(url) }
+```
+
+##### `handleCustomTap(for type: ActiveType, handler: (String) -> ())`
+
+```swift
+label.handleCustomTap(for: customType) { element in print("\(element) tapped") }
 ```
 
 ##### `filterHashtag: (String) -> Bool`


### PR DESCRIPTION
#### :tophat: What? Why?
The ability to highlight custom patterns has been highly demanded in the past months. Unfortunately, and I am really sorry, I had no time to work on in until now.

I have to say that the implementation is not completely my own, ActiveLabel has received a lot of PR demanding the addition of custom patters, I this implementation is partially based on some of the received PRs.

It also introduces a way to enable/disable desired highlighting patterns. So, now is when it is going to be possible to add more types without reducing performance.

#### :pushpin: Related tasks?
There are, ATM, 3 PR that are completely related with this one. #72 , #89 , #90 

#### :ghost: GIF
![](https://m.popkey.co/5f5049/qVRdD.gif)