### PR TITLE
Opened up a function configureLinkAttribute to allow fully customizable NSAttributedString

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -80,6 +80,14 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     open func handleCustomTap(for type: ActiveType, handler: @escaping (String) -> ()) {
         customTapHandlers[type] = handler
     }
+	
+    open func removeHandleCustomTap(for type: ActiveType) {
+        customTapHandlers[type] = nil
+    }
+	
+    open func removeAllHandleCustomTaps() {
+        customTapHandlers.removeAll()
+    }
 
     open func filterMention(_ predicate: @escaping (String) -> Bool) {
         mentionFilterPredicate = predicate
@@ -281,8 +289,8 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
         return CGPoint(x: rect.origin.x, y: glyphOriginY)
     }
 	
-	public typealias ConfigureLinkAttribute = (ActiveType, [String: Any]) -> ([String: Any])
-	public var configureLinkAttribute: ConfigureLinkAttribute?
+    public typealias ConfigureLinkAttribute = (ActiveType, [String: Any]) -> ([String: Any])
+    public var configureLinkAttribute: ConfigureLinkAttribute?
 
     /// add link attribute
     fileprivate func addLinkAttribute(_ mutAttrString: NSMutableAttributedString) {
@@ -308,9 +316,9 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
                 attributes[NSFontAttributeName] = highlightFont
             }
 			
-			if let configureLinkAttribute = configureLinkAttribute {
-				attributes = configureLinkAttribute(type, attributes)
-			}
+            if let configureLinkAttribute = configureLinkAttribute {
+                attributes = configureLinkAttribute(type, attributes)
+            }
 
             for element in elements {
                 mutAttrString.setAttributes(attributes, range: element.range)

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -13,7 +13,7 @@ public protocol ActiveLabelDelegate: class {
     func didSelect(_ text: String, type: ActiveType)
 }
 
-public typealias ConfigureLinkAttribute = (ActiveType, [String : Any]) -> ([String : Any])
+public typealias ConfigureLinkAttribute = (ActiveType, [String : Any], Bool) -> ([String : Any])
 typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveType)
 
 @IBDesignable open class ActiveLabel: UILabel {
@@ -246,8 +246,16 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     fileprivate lazy var layoutManager = NSLayoutManager()
     fileprivate lazy var textContainer = NSTextContainer()
     lazy var activeElements = [ActiveType: [ElementTuple]]()
+    
+    // MARK: - internal (used for testing)
+    
+    // Needed for unit testing
+    internal var textStorageAttributedString: NSAttributedString {
+        return NSAttributedString(attributedString: textStorage)
+    }
 
     // MARK: - helper functions
+    
     fileprivate func setupLabel() {
         textStorage.addLayoutManager(layoutManager)
         layoutManager.addTextContainer(textContainer)
@@ -322,7 +330,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             }
 			
             if let configureLinkAttribute = configureLinkAttribute {
-                attributes = configureLinkAttribute(type, attributes)
+                attributes = configureLinkAttribute(type, attributes, false)
             }
 
             for element in elements {
@@ -412,6 +420,10 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
         
         if let highlightFont = hightlightFont {
             attributes[NSFontAttributeName] = highlightFont
+        }
+        
+        if let configureLinkAttribute = configureLinkAttribute {
+            attributes = configureLinkAttribute(type, attributes, isSelected)
         }
 
         textStorage.addAttributes(attributes, range: selectedElement.range)

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -280,6 +280,9 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
         let glyphOriginY = heightCorrection > 0 ? rect.origin.y + heightCorrection : rect.origin.y
         return CGPoint(x: rect.origin.x, y: glyphOriginY)
     }
+	
+	public typealias ConfigureLinkAttribute = (ActiveType, [String: Any]) -> ([String: Any])
+	public var configureLinkAttribute: ConfigureLinkAttribute?
 
     /// add link attribute
     fileprivate func addLinkAttribute(_ mutAttrString: NSMutableAttributedString) {
@@ -304,6 +307,10 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             if let highlightFont = hightlightFont {
                 attributes[NSFontAttributeName] = highlightFont
             }
+			
+			if let configureLinkAttribute = configureLinkAttribute {
+				attributes = configureLinkAttribute(type, attributes)
+			}
 
             for element in elements {
                 mutAttrString.setAttributes(attributes, range: element.range)

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -232,27 +232,20 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     fileprivate var _customizing: Bool = true
     fileprivate var defaultCustomColor: UIColor = .black
     
-    fileprivate var mentionTapHandler: ((String) -> ())?
-    fileprivate var hashtagTapHandler: ((String) -> ())?
-    fileprivate var urlTapHandler: ((URL) -> ())?
-    fileprivate var customTapHandlers: [ActiveType : ((String) -> ())] = [:]
+    internal var mentionTapHandler: ((String) -> ())?
+    internal var hashtagTapHandler: ((String) -> ())?
+    internal var urlTapHandler: ((URL) -> ())?
+    internal var customTapHandlers: [ActiveType : ((String) -> ())] = [:]
     
     fileprivate var mentionFilterPredicate: ((String) -> Bool)?
     fileprivate var hashtagFilterPredicate: ((String) -> Bool)?
 
     fileprivate var selectedElement: ElementTuple?
     fileprivate var heightCorrection: CGFloat = 0
-    fileprivate lazy var textStorage = NSTextStorage()
+    internal lazy var textStorage = NSTextStorage()
     fileprivate lazy var layoutManager = NSLayoutManager()
     fileprivate lazy var textContainer = NSTextContainer()
     lazy var activeElements = [ActiveType: [ElementTuple]]()
-    
-    // MARK: - internal (used for testing)
-    
-    // Needed for unit testing
-    internal var textStorageAttributedString: NSAttributedString {
-        return NSAttributedString(attributedString: textStorage)
-    }
 
     // MARK: - helper functions
     

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -18,9 +18,11 @@ class ViewController: UIViewController {
 
         let customType = ActiveType.custom(pattern: "\\sare\\b") //Looks for "are"
         let customType2 = ActiveType.custom(pattern: "\\sit\\b") //Looks for "it"
+        let customType3 = ActiveType.custom(pattern: "\\ssupports\\b") //Looks for "supports"
 
         label.enabledTypes.append(customType)
         label.enabledTypes.append(customType2)
+        label.enabledTypes.append(customType3)
 
         label.urlMaximumLength = 31
 
@@ -47,9 +49,21 @@ class ViewController: UIViewController {
             label.customSelectedColor[customType] = UIColor.green
             label.customColor[customType2] = UIColor.magenta
             label.customSelectedColor[customType2] = UIColor.green
+            
+            label.configureLinkAttribute = { (type, attributes, isSelected) in
+                var atts = attributes
+                switch type {
+                case customType3:
+                    atts[NSFontAttributeName] = isSelected ? UIFont.boldSystemFont(ofSize: 16) : UIFont.boldSystemFont(ofSize: 14)
+                default: ()
+                }
+                
+                return atts
+            }
 
             label.handleCustomTap(for: customType) { self.alert("Custom type", message: $0) }
             label.handleCustomTap(for: customType2) { self.alert("Custom type", message: $0) }
+            label.handleCustomTap(for: customType3) { self.alert("Custom type", message: $0) }
         }
 
         label.frame = CGRect(x: 20, y: 40, width: view.frame.width - 40, height: 300)

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -254,34 +254,43 @@ class ActiveTypeTests: XCTestCase {
         XCTAssertTrue(foundCustomAttributedStyling)
     }
 
-    func testRemoveHandle() {
+    func testRemoveHandleMention() {
+        label.handleMentionTap({_ in })
+        XCTAssertNotNil(label.handleMentionTap)
+        
+        label.removeHandle(for: .mention)
+        XCTAssertNil(label.mentionTapHandler)
+    }
+    
+    func testRemoveHandleHashtag() {
+        label.handleHashtagTap({_ in })
+        XCTAssertNotNil(label.handleHashtagTap)
+        
+        label.removeHandle(for: .hashtag)
+        XCTAssertNil(label.hashtagTapHandler)
+    }
+    
+    func testRemoveHandleURL() {
+        label.handleURLTap({_ in })
+        XCTAssertNotNil(label.handleURLTap)
+        
+        label.removeHandle(for: .url)
+        XCTAssertNil(label.urlTapHandler)
+    }
+    
+    func testRemoveHandleCustom() {
         let newType1 = ActiveType.custom(pattern: "\\sare1\\b")
         let newType2 = ActiveType.custom(pattern: "\\sare2\\b")
         
-        label.handleMentionTap({_ in })
-        label.handleHashtagTap({_ in })
-        label.handleURLTap({_ in })
         label.handleCustomTap(for: newType1, handler: {_ in })
         label.handleCustomTap(for: newType2, handler: {_ in })
-        
-        // Test some
-        XCTAssertNotNil(label.handleMentionTap)
-        XCTAssertNotNil(label.handleHashtagTap)
-        XCTAssertNotNil(label.handleURLTap)
         XCTAssertEqual(label.customTapHandlers.count, 2)
         
-        // Rest removal
-        label.removeHandle(for: .mention)
-        label.removeHandle(for: .hashtag)
-        label.removeHandle(for: .url)
         label.removeHandle(for: newType1)
-        label.removeHandle(for: newType2)
+        XCTAssertEqual(label.customTapHandlers.count, 1)
         
-        XCTAssertNil(label.mentionTapHandler)
-        XCTAssertNil(label.hashtagTapHandler)
-        XCTAssertNil(label.urlTapHandler)
+        label.removeHandle(for: newType2)
         XCTAssertEqual(label.customTapHandlers.count, 0)
-
     }
 
     func testFiltering() {

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -222,6 +222,38 @@ class ActiveTypeTests: XCTestCase {
         label.text = "google"
         XCTAssertEqual(activeElements.count, 0)
     }
+    
+    func testConfigureLinkAttributes() {
+        // Customize label
+        let newType = ActiveType.custom(pattern: "\\sare\\b")
+        label.customize { label in
+            label.enabledTypes = [newType]
+            
+            // Configure "are" to be system font / bold / 14
+            label.configureLinkAttribute = { type, attributes, isSelected in
+                var atts = attributes
+                if case newType = type {
+                    atts[NSFontAttributeName] = UIFont.boldSystemFont(ofSize: 14)
+                }
+                
+                return atts
+            }
+            label.text = "we are one"
+        }
+        
+        // Find attributed text
+        let range = (label.text! as NSString).range(of: "are")
+        let areText = label.textStorageAttributedString.attributedSubstring(from: range)
+        
+        // Enumber after attributes and find our font
+        var foundCustomAttributedStyling = false
+        areText.enumerateAttributes(in: NSRange(location: 0, length: areText.length), options: [.longestEffectiveRangeNotRequired], using: { (attributes, range, stop) in
+            foundCustomAttributedStyling = attributes[NSFontAttributeName] as? UIFont == UIFont.boldSystemFont(ofSize: 14)
+        })
+
+        XCTAssertTrue(foundCustomAttributedStyling)
+    }
+
 
     func testFiltering() {
         label.text = "@user #tag"

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -243,7 +243,7 @@ class ActiveTypeTests: XCTestCase {
         
         // Find attributed text
         let range = (label.text! as NSString).range(of: "are")
-        let areText = label.textStorageAttributedString.attributedSubstring(from: range)
+        let areText = label.textStorage.attributedSubstring(from: range)
         
         // Enumber after attributes and find our font
         var foundCustomAttributedStyling = false
@@ -254,6 +254,35 @@ class ActiveTypeTests: XCTestCase {
         XCTAssertTrue(foundCustomAttributedStyling)
     }
 
+    func testRemoveHandle() {
+        let newType1 = ActiveType.custom(pattern: "\\sare1\\b")
+        let newType2 = ActiveType.custom(pattern: "\\sare2\\b")
+        
+        label.handleMentionTap({_ in })
+        label.handleHashtagTap({_ in })
+        label.handleURLTap({_ in })
+        label.handleCustomTap(for: newType1, handler: {_ in })
+        label.handleCustomTap(for: newType2, handler: {_ in })
+        
+        // Test some
+        XCTAssertNotNil(label.handleMentionTap)
+        XCTAssertNotNil(label.handleHashtagTap)
+        XCTAssertNotNil(label.handleURLTap)
+        XCTAssertEqual(label.customTapHandlers.count, 2)
+        
+        // Rest removal
+        label.removeHandle(for: .mention)
+        label.removeHandle(for: .hashtag)
+        label.removeHandle(for: .url)
+        label.removeHandle(for: newType1)
+        label.removeHandle(for: newType2)
+        
+        XCTAssertNil(label.mentionTapHandler)
+        XCTAssertNil(label.hashtagTapHandler)
+        XCTAssertNil(label.urlTapHandler)
+        XCTAssertEqual(label.customTapHandlers.count, 0)
+
+    }
 
     func testFiltering() {
         label.text = "@user #tag"


### PR DESCRIPTION
Allows full customization of `customTap` by opening up the `NSAttributedString` configuration in a callback

I, personally, needed this to bold the username at the start of a comment label and this seemed like the best, easiest, and most flexible solution

Somewhat helps #97 and #118 

Example below simply sets the username at the beginning of the label to a bold system font of size 14
```swift
let customType = ActiveType.custom(pattern: "^\(username)\\b")
lblComment.enabledTypes = [.mention, .hashtag, .url, customType]

lblComment.configureLinkAttribute = { (type, attributes, isSelected) in
	var atts = attributes
	switch type {
	case .custom:
		atts[NSFontAttributeName] = isSelected ? UIFont.boldSystemFontOfSize(16) : UIFont.boldSystemFontOfSize(14)
	default: ()
	}
	
	return atts
}

lblComment.handleCustomTap(for: customType) { element in
	print("Custom type tapped: \(element)")
}
```