### PR TITLE
Updated URL parser to use NSDataDetector

### DIFF
--- a/ActiveLabel/ActiveBuilder.swift
+++ b/ActiveLabel/ActiveBuilder.swift
@@ -51,7 +51,7 @@ struct ActiveBuilder {
 
             guard let maxLenght = maximumLenght, word.characters.count > maxLenght else {
                 let range = maximumLenght == nil ? match.range : (text as NSString).range(of: word)
-                let element = ActiveElement.create(with: type, text: word)
+                let element = ActiveElement.url(original: word, trimmed: word, url: match.url)
                 elements.append((range, element, type))
                 continue
             }
@@ -60,7 +60,7 @@ struct ActiveBuilder {
             text = text.replacingOccurrences(of: word, with: trimmedWord)
 
             let newRange = (text as NSString).range(of: trimmedWord)
-            let element = ActiveElement.url(original: word, trimmed: trimmedWord)
+            let element = ActiveElement.url(original: word, trimmed: trimmedWord, url: match.url)
             elements.append((newRange, element, type))
         }
         return (elements, text)

--- a/ActiveLabel/ActiveBuilder.swift
+++ b/ActiveLabel/ActiveBuilder.swift
@@ -26,7 +26,22 @@ struct ActiveBuilder {
     static func createURLElements(from text: String, range: NSRange, maximumLenght: Int?) -> ([ElementTuple], String) {
         let type = ActiveType.url
         var text = text
-        let matches = RegexParser.getElements(from: text, with: type.pattern, range: range)
+        
+        let detector: NSDataDetector?
+        var matches: [NSTextCheckingResult] = []
+        
+        do {
+            try detector = NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        } catch {
+            detector = nil
+        }
+        
+        if let detector = detector {
+            matches = detector.matches(in: text, options: [], range: NSRange(location: 0, length: text.utf16.count))
+        } else {
+            matches = RegexParser.getElements(from: text, with: type.pattern, range: range)
+        }
+        
         let nsstring = text as NSString
         var elements: [ElementTuple] = []
 

--- a/ActiveLabel/ActiveBuilder.swift
+++ b/ActiveLabel/ActiveBuilder.swift
@@ -23,7 +23,7 @@ struct ActiveBuilder {
         }
     }
 
-    static func createURLElements(from text: String, range: NSRange, maximumLenght: Int?) -> ([ElementTuple], String) {
+    static func createURLElements(from text: String, range: NSRange, maximumLength: Int?) -> ([ElementTuple], String) {
         let type = ActiveType.url
         var text = text
         
@@ -49,14 +49,14 @@ struct ActiveBuilder {
             let word = nsstring.substring(with: match.range)
                 .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 
-            guard let maxLenght = maximumLenght, word.characters.count > maxLenght else {
-                let range = maximumLenght == nil ? match.range : (text as NSString).range(of: word)
+            guard let maxLength = maximumLength, word.characters.count > maxLength else {
+                let range = maximumLength == nil ? match.range : (text as NSString).range(of: word)
                 let element = ActiveElement.url(original: word, trimmed: word, url: match.url)
                 elements.append((range, element, type))
                 continue
             }
 
-            let trimmedWord = word.trim(to: maxLenght)
+            let trimmedWord = word.trim(to: maxLength)
             text = text.replacingOccurrences(of: word, with: trimmedWord)
 
             let newRange = (text as NSString).range(of: trimmedWord)

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -206,10 +206,18 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             guard let selectedElement = selectedElement else { return avoidSuperCall }
 
             switch selectedElement.element {
-            case .mention(let userHandle): didTapMention(userHandle)
-            case .hashtag(let hashtag): didTapHashtag(hashtag)
-            case .url(let originalURL, _): didTapStringURL(originalURL)
-            case .custom(let element): didTap(element, for: selectedElement.type)
+            case .mention(let userHandle):
+                didTapMention(userHandle)
+            case .hashtag(let hashtag):
+                didTapHashtag(hashtag)
+            case .url(let originalURL, _, let url):
+                if let url = url {
+                    didTapURL(url)
+                } else {
+                    didTapStringURL(originalURL)
+                }
+            case .custom(let element):
+                didTap(element, for: selectedElement.type)
             }
             
             let when = DispatchTime.now() + Double(Int64(0.25 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
@@ -493,6 +501,14 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     fileprivate func didTapStringURL(_ stringURL: String) {
         guard let urlHandler = urlTapHandler, let url = URL(string: stringURL) else {
             delegate?.didSelect(stringURL, type: .url)
+            return
+        }
+        urlHandler(url)
+    }
+    
+    fileprivate func didTapURL(_ url: URL) {
+        guard let urlHandler = urlTapHandler else {
+            delegate?.didSelect(url.absoluteString, type: .url)
             return
         }
         urlHandler(url)

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -347,7 +347,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
         var textRange = NSRange(location: 0, length: textLength)
 
         if enabledTypes.contains(.url) {
-            let tuple = ActiveBuilder.createURLElements(from: textString, range: textRange, maximumLenght: urlMaximumLength)
+            let tuple = ActiveBuilder.createURLElements(from: textString, range: textRange, maximumLength: urlMaximumLength)
             let urlElements = tuple.0
             let finalText = tuple.1
             textString = finalText

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -11,14 +11,14 @@ import Foundation
 enum ActiveElement {
     case mention(String)
     case hashtag(String)
-    case url(original: String, trimmed: String)
+    case url(original: String, trimmed: String, url: URL?)
     case custom(String)
 
     static func create(with activeType: ActiveType, text: String) -> ActiveElement {
         switch activeType {
         case .mention: return mention(text)
         case .hashtag: return hashtag(text)
-        case .url: return url(original: text, trimmed: text)
+        case .url: return url(original: text, trimmed: text, url: nil)
         case .custom: return custom(text)
         }
     }

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -29,7 +29,9 @@ class ViewController: UIViewController {
         label.customize { label in
             label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like" +
             " this one: http://optonaut.co. Now it also supports custom patterns -> are\n\n" +
-                "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601"
+                "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601" +
+                "\n\n" +
+                "Now it also supports simple links: google.com"
             label.numberOfLines = 0
             label.lineSpacing = 4
             


### PR DESCRIPTION
We needed to support user-entered links such as google.com, but the current RegEx based approach was too complicated to support this. We switched to using an NSDataDetector instead, which supports a myriad of link types, auto-parses and converts them to a proper URL object. Updated approach falls back to the RegEx pattern if the data detector cannot be instantiated for any reason.