### PR TITLE
Add under line options

### DIFF
--- a/ActiveLabel/ActiveBuilder.swift
+++ b/ActiveLabel/ActiveBuilder.swift
@@ -62,11 +62,15 @@ struct ActiveBuilder {
         var elements: [ElementTuple] = []
 
         for match in matches where match.range.length > minLength {
-            let word = nsstring.substring(with: match.range)
-                .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            let matched = nsstring.substring(with: match.range)
+            let word = matched.trimmingCharacters(in: .whitespacesAndNewlines)
+            let rangeInMatched = matched.range(of: word)
+            let distance = matched.distance(from: matched.startIndex, to: rangeInMatched?.lowerBound ?? matched.startIndex)
+            let range = NSRange(location: match.range.location + distance, length: word.characters.count)
+
             if filterPredicate?(word) ?? true {
                 let element = ActiveElement.create(with: type, text: word)
-                elements.append((match.range, element, type))
+                elements.append((range, element, type))
             }
         }
         return elements
@@ -92,7 +96,7 @@ struct ActiveBuilder {
 
             if filterPredicate?(word) ?? true {
                 let element = ActiveElement.create(with: type, text: word)
-                elements.append((match.range, element, type))
+                elements.append((range, element, type))
             }
         }
         return elements

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -33,10 +33,16 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     @IBInspectable open var mentionSelectedColor: UIColor? {
         didSet { updateTextStorage(parseText: false) }
     }
+    open var mentionUnderLineStyle: NSUnderlineStyle = .styleNone {
+        didSet { updateTextStorage(parseText: false) }
+    }
     @IBInspectable open var hashtagColor: UIColor = .blue {
         didSet { updateTextStorage(parseText: false) }
     }
     @IBInspectable open var hashtagSelectedColor: UIColor? {
+        didSet { updateTextStorage(parseText: false) }
+    }
+    open var hashtagUnderLineStyle: NSUnderlineStyle = .styleNone {
         didSet { updateTextStorage(parseText: false) }
     }
     @IBInspectable open var URLColor: UIColor = .blue {
@@ -45,10 +51,16 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     @IBInspectable open var URLSelectedColor: UIColor? {
         didSet { updateTextStorage(parseText: false) }
     }
+    open var URLUnderLineStyle: NSUnderlineStyle = .styleNone {
+        didSet { updateTextStorage(parseText: false) }
+    }
     open var customColor: [ActiveType : UIColor] = [:] {
         didSet { updateTextStorage(parseText: false) }
     }
     open var customSelectedColor: [ActiveType : UIColor] = [:] {
+        didSet { updateTextStorage(parseText: false) }
+    }
+    open var customUnderLineStyle: [ActiveType : NSUnderlineStyle] = [:] {
         didSet { updateTextStorage(parseText: false) }
     }
     @IBInspectable public var lineSpacing: CGFloat = 0 {
@@ -315,10 +327,18 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
         for (type, elements) in activeElements {
 
             switch type {
-            case .mention: attributes[NSForegroundColorAttributeName] = mentionColor
-            case .hashtag: attributes[NSForegroundColorAttributeName] = hashtagColor
-            case .url: attributes[NSForegroundColorAttributeName] = URLColor
-            case .custom: attributes[NSForegroundColorAttributeName] = customColor[type] ?? defaultCustomColor
+            case .mention:
+                attributes[NSForegroundColorAttributeName] = mentionColor
+                attributes[NSUnderlineStyleAttributeName] = mentionUnderLineStyle.rawValue
+            case .hashtag:
+                attributes[NSForegroundColorAttributeName] = hashtagColor
+                attributes[NSUnderlineStyleAttributeName] = hashtagUnderLineStyle.rawValue
+            case .url:
+                attributes[NSForegroundColorAttributeName] = URLColor
+                attributes[NSUnderlineStyleAttributeName] = URLUnderLineStyle.rawValue
+            case .custom:
+                attributes[NSForegroundColorAttributeName] = customColor[type] ?? defaultCustomColor
+                attributes[NSUnderlineStyleAttributeName] = customUnderLineStyle[type]?.rawValue ?? NSUnderlineStyle.styleNone.rawValue
             }
             
             if let highlightFont = hightlightFont {

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -35,9 +35,12 @@ class ViewController: UIViewController {
             
             label.textColor = UIColor(red: 102.0/255, green: 117.0/255, blue: 127.0/255, alpha: 1)
             label.hashtagColor = UIColor(red: 85.0/255, green: 172.0/255, blue: 238.0/255, alpha: 1)
+            label.hashtagUnderLineStyle = .styleSingle
             label.mentionColor = UIColor(red: 238.0/255, green: 85.0/255, blue: 96.0/255, alpha: 1)
+            label.mentionUnderLineStyle = .styleDouble
             label.URLColor = UIColor(red: 85.0/255, green: 238.0/255, blue: 151.0/255, alpha: 1)
             label.URLSelectedColor = UIColor(red: 82.0/255, green: 190.0/255, blue: 41.0/255, alpha: 1)
+            label.URLUnderLineStyle = .styleThick
 
             label.handleMentionTap { self.alert("Mention", message: $0) }
             label.handleHashtagTap { self.alert("Hashtag", message: $0) }
@@ -47,8 +50,11 @@ class ViewController: UIViewController {
 
             label.customColor[customType] = UIColor.purple
             label.customSelectedColor[customType] = UIColor.green
+            label.customUnderLineStyle[customType] = .styleNone
             label.customColor[customType2] = UIColor.magenta
             label.customSelectedColor[customType2] = UIColor.green
+            label.customUnderLineStyle[customType2] = NSUnderlineStyle(rawValue: NSUnderlineStyle.styleSingle.rawValue | NSUnderlineStyle.patternDot.rawValue) ?? .styleNone
+
             
             label.configureLinkAttribute = { (type, attributes, isSelected) in
                 var atts = attributes

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Example:
             label.hashtagColor = UIColor(red: 85.0/255, green: 172.0/255, blue: 238.0/255, alpha: 1)
             label.mentionColor = UIColor(red: 238.0/255, green: 85.0/255, blue: 96.0/255, alpha: 1)
             label.URLColor = UIColor(red: 85.0/255, green: 238.0/255, blue: 151.0/255, alpha: 1)
+            label.URLUnderLineStyle = .styleSingle
             label.handleMentionTap { self.alert("Mention", message: $0) }
             label.handleHashtagTap { self.alert("Hashtag", message: $0) }
             label.handleURLTap { self.alert("URL", message: $0.absoluteString) }
@@ -96,12 +97,16 @@ From now on, a url that's bigger than that, will be trimmed.
 
 ##### `mentionColor: UIColor = .blueColor()`
 ##### `mentionSelectedColor: UIColor?`
+##### `mentionUnderLineStyle: NSUnderlineStyle = .styleNone`
 ##### `hashtagColor: UIColor = .blueColor()`
 ##### `hashtagSelectedColor: UIColor?`
+##### `hashtagUnderLineStyle: NSUnderlineStyle = .styleNone`
 ##### `URLColor: UIColor = .blueColor()`
 ##### `URLSelectedColor: UIColor?`
+##### `URLUnderLineStyle: NSUnderlineStyle = .styleNone`
 #### `customColor: [ActiveType : UIColor]`
 #### `customSelectedColor: [ActiveType : UIColor]`
+#### `customUnderLineStyle: [ActiveType : NSUnderlineStyle]`
 ##### `lineSpacing: Float?`
 
 ##### `handleMentionTap: (String) -> ()`


### PR DESCRIPTION
Add under line options to all ActiveTypes.(related to #104)
And changed ActiveElement's range to trimmed range.
Because regular expression result often contains white space.
It is not pretty.
**before**
<img width="677" alt="screen shot 2017-01-21 at 4 36 21" src="https://cloud.githubusercontent.com/assets/1977135/22164345/2db81818-df9a-11e6-89c4-333a82752aa8.png">
**after**
<img width="674" alt="screen shot 2017-01-21 at 4 45 00" src="https://cloud.githubusercontent.com/assets/1977135/22164350/33b7a03a-df9a-11e6-87c4-961db5a4f61e.png">

