### PR TITLE
Enable user to disable all touching

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -60,6 +60,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     @IBInspectable public var highlightFontName: String? = nil {
         didSet { updateTextStorage(parseText: false) }
     }
+    @IBInspectable public var ignoreTouches: Bool = false
     public var highlightFontSize: CGFloat? = nil {
         didSet { updateTextStorage(parseText: false) }
     }
@@ -189,6 +190,10 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
 
     // MARK: - touch events
     func onTouch(_ touch: UITouch) -> Bool {
+        if (ignoreTouches) {
+            return false
+        }
+        
         let location = touch.location(in: self)
         var avoidSuperCall = false
 

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -19,17 +19,20 @@ class ViewController: UIViewController {
         let customType = ActiveType.custom(pattern: "\\sare\\b") //Looks for "are"
         let customType2 = ActiveType.custom(pattern: "\\sit\\b") //Looks for "it"
         let customType3 = ActiveType.custom(pattern: "\\ssupports\\b") //Looks for "supports"
+        let customType4 = ActiveType.custom(pattern: "housing.temp")
 
         label.enabledTypes.append(customType)
         label.enabledTypes.append(customType2)
         label.enabledTypes.append(customType3)
+        label.enabledTypes.append(customType4)
 
         label.urlMaximumLength = 31
 
         label.customize { label in
             label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like" +
             " this one: http://optonaut.co. Now it also supports custom patterns -> are\n\n" +
-                "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601"
+                "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601" +
+            "Let's try my link: housing.temp"
             label.numberOfLines = 0
             label.lineSpacing = 4
             
@@ -64,6 +67,7 @@ class ViewController: UIViewController {
             label.handleCustomTap(for: customType) { self.alert("Custom type", message: $0) }
             label.handleCustomTap(for: customType2) { self.alert("Custom type", message: $0) }
             label.handleCustomTap(for: customType3) { self.alert("Custom type", message: $0) }
+            label.handleCustomTap(for: customType4) { self.alert("Custom type", message: $0) }
         }
 
         label.frame = CGRect(x: 20, y: 40, width: view.frame.width - 40, height: 300)

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -433,4 +433,14 @@ class ActiveTypeTests: XCTestCase {
         }
 
     }
+    
+    func testIgnoreTouches() {
+        label.text = "#somehashtag"
+        var notIgnored = label.onTouch(UITouch())
+        XCTAssertTrue(notIgnored)
+        
+        label.ignoreTouches = true
+        notIgnored = label.onTouch(UITouch())
+        XCTAssertFalse(notIgnored)
+    }
 }


### PR DESCRIPTION
I want to use ActiveLabel in a UICollectionViewCell. My desire is for hashtags and links to be highlighted, which ActiveLabel does, but I do not want them to be selectable on this screen. However, ActiveLabel currently blocks touches from going through to the superview even if I'm not handling the touches. By adding an `ignoreTouches` option, I am able to use ActiveLabel but still allow my UICollectionViewCell to receive the tap.