### PR TITLE
Fix for attributed string attributes loss

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -277,6 +277,9 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             clearActiveElements()
             let newString = parseTextAndExtractActiveElements(mutAttrString)
             mutAttrString.mutableString.setString(newString)
+            attributedText.enumerateAttributes(in: NSRange(location: 0, length: attributedText.length), options: .longestEffectiveRangeNotRequired, using: { (attribute, range, stop) in
+                mutAttrString.addAttributes(attribute, range: range)
+            })
         }
 
         addLinkAttribute(mutAttrString)


### PR DESCRIPTION
Fixed NSAttributedString setString issue that removes original attributes by enumerating the original attributes and copying them to the new element

this PR should fix https://github.com/optonaut/ActiveLabel.swift/issues/219