### PR TITLE
Fix tests for custom type

### DIFF
--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -26,12 +26,12 @@ class ActiveTypeTests: XCTestCase {
     let label = ActiveLabel()
     let customEmptyType = ActiveType.custom(pattern: "")
     
-    var activeElements: [ActiveElement] {
-        return label.activeElements.flatMap({$0.1.compactMap({$0.element})})
+    var activeElements: [ElementTuple] {
+        return label.activeElements.flatMap({$0.1.compactMap({$0})})
     }
     
     var currentElementString: String? {
-        guard let currentElement = activeElements.first else { return nil }
+        guard let (_, currentElement, _) = activeElements.first else { return nil }
         switch currentElement {
         case .mention(let mention): return mention
         case .hashtag(let hashtag): return hashtag
@@ -41,13 +41,8 @@ class ActiveTypeTests: XCTestCase {
     }
     
     var currentElementType: ActiveType? {
-        guard let currentElement = activeElements.first else { return nil }
-        switch currentElement {
-        case .mention: return .mention
-        case .hashtag: return .hashtag
-        case .url: return .url
-        case .custom: return customEmptyType
-        }
+        guard let (_, _, type) = activeElements.first else { return nil }
+        return type
     }
     
     override func setUp() {
@@ -424,7 +419,7 @@ class ActiveTypeTests: XCTestCase {
 
         XCTAssertNotEqual(text.count, label.text!.count)
 
-        switch activeElements.first! {
+        switch activeElements.first!.element {
         case .url(let original, let trimmed):
             XCTAssertEqual(original, url)
             XCTAssertEqual(trimmed, trimmedURL)

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -24,7 +24,6 @@ public func ==(a: ActiveElement, b: ActiveElement) -> Bool {
 class ActiveTypeTests: XCTestCase {
     
     let label = ActiveLabel()
-    let customEmptyType = ActiveType.custom(pattern: "")
     
     var activeElements: [ElementTuple] {
         return label.activeElements.flatMap({$0.1.compactMap({$0})})
@@ -202,17 +201,17 @@ class ActiveTypeTests: XCTestCase {
         label.text = "we are one"
         XCTAssertEqual(activeElements.count, 1)
         XCTAssertEqual(currentElementString, "are")
-        XCTAssertEqual(currentElementType, customEmptyType)
+        XCTAssertEqual(currentElementType, newType)
 
         label.text = "are. are"
         XCTAssertEqual(activeElements.count, 1)
         XCTAssertEqual(currentElementString, "are")
-        XCTAssertEqual(currentElementType, customEmptyType)
+        XCTAssertEqual(currentElementType, newType)
 
         label.text = "helloare are"
         XCTAssertEqual(activeElements.count, 1)
         XCTAssertEqual(currentElementString, "are")
-        XCTAssertEqual(currentElementType, customEmptyType)
+        XCTAssertEqual(currentElementType, newType)
 
         label.text = "google"
         XCTAssertEqual(activeElements.count, 0)
@@ -378,7 +377,7 @@ class ActiveTypeTests: XCTestCase {
         label.text = "http://www.google.com  are #hello"
         XCTAssertEqual(activeElements.count, 1)
         XCTAssertEqual(currentElementString, "are")
-        XCTAssertEqual(currentElementType, customEmptyType)
+        XCTAssertEqual(currentElementType, newType)
 
         label.text = "@user"
         XCTAssertEqual(activeElements.count, 0)
@@ -389,7 +388,7 @@ class ActiveTypeTests: XCTestCase {
         label.text = " http://www.apple.com are @userNumberOne #hashtag http://www.google.com are @anotheruser"
         XCTAssertEqual(activeElements.count, 2)
         XCTAssertEqual(currentElementString, "are")
-        XCTAssertEqual(currentElementType, customEmptyType)
+        XCTAssertEqual(currentElementType, newType)
     }
 
     func testStringTrimming() {


### PR DESCRIPTION
I noticed that type assertions for custom type were comparing a dummy custom type, `customEmptyType`, with `customEmptyType`, instead of comparing the actual type with the expected type.
