### PR TITLE
Handle cancel state as ended state

### DIFF
--- a/ActiveLabel.podspec
+++ b/ActiveLabel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name    = 'ActiveLabel'
-	s.version = '1.0.1'
+	s.version = '1.0.2'
 
 	s.author      = { 'Optonaut' => 'hello@optonaut.co' }
 	s.homepage    = 'https://github.com/optonaut/ActiveLabel.swift'

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -205,7 +205,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
                 updateAttributesWhenSelected(false)
                 selectedElement = nil
             }
-        case .ended:
+        case .ended, .cancelled:
             guard let selectedElement = selectedElement else { return avoidSuperCall }
 
             switch selectedElement.element {
@@ -221,10 +221,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
                 self.selectedElement = nil
             }
             avoidSuperCall = true
-        case .cancelled:
-            updateAttributesWhenSelected(false)
-            selectedElement = nil
-        case .stationary:
+        default:
             break
         }
 


### PR DESCRIPTION
I have a collection view cell, ActiveLabel in this cell. 
Tap on link causes `cancelled` state. The solution is to handle `cancelled` state the same as `ended`. More in #255.
IMO it's a strange behaviour and need more research. Anyway, this hot fix works as expected.