### PR TITLE
have-modified-the-detection-length-of-hashtag-and-metion

### DIFF
--- a/ActiveLabel/ActiveBuilder.swift
+++ b/ActiveLabel/ActiveBuilder.swift
@@ -80,7 +80,7 @@ struct ActiveBuilder {
         let nsstring = text as NSString
         var elements: [ElementTuple] = []
 
-        for match in matches where match.range.length > 2 {
+        for match in matches where match.range.length >= 2 {
             let range = NSRange(location: match.range.location + 1, length: match.range.length - 1)
             var word = nsstring.substring(with: range)
             if word.hasPrefix("@") {


### PR DESCRIPTION
It does not get detected by ActiveLabel when both hashtag and mention have only one letter at the first.  In the `CreateElementingFirstCharator (from:for:for:range:filterPredicted)`method, I have modified a conditional that  `hashtag` and `mentions` is not included when length is 1 at first letter.

### before 

`#a` string is not detected 

```swift
class TestViewController: UIViewController {
    var hashTagLabel = ActiveLabel(frame: CGRect(x: 0, y: 100, width: UIScreen.main.bounds.width, height: 200))
    override func viewDidLoad() {
        super.viewDidLoad()
        hashTagLabel.customize {
            $0.numberOfLines = 0
            $0.enabledTypes = [.hashtag, .mention]
            $0.hashtagColor = .blue
            $0.textColor = .black
            $0.text = "#a #b #cd #123 #4567"
            $0.handleHashtagTap{ hashTag in print(hashTag) }
        }
        view.addSubview(hashTagLabel)       
    }
}
```

![no-detect](https://user-images.githubusercontent.com/30401511/51424070-2d7f1800-1c0c-11e9-96eb-df9ad19f24a3.png)

### after 

![detect](https://user-images.githubusercontent.com/30401511/51424085-67501e80-1c0c-11e9-9b5d-09d78abe1e35.png)


