### PR TITLE
Added automatic URL percent encoding

### DIFF
--- a/ActiveLabel.xcodeproj/project.pbxproj
+++ b/ActiveLabel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		786936A722200FAE00E52AC5 /* ActiveLabelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786936A622200FAD00E52AC5 /* ActiveLabelHandler.swift */; };
 		8F0249A61B9989B1005D8035 /* ActiveLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F0249A51B9989B1005D8035 /* ActiveLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8F0249AD1B9989B1005D8035 /* ActiveLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0249A21B9989B1005D8035 /* ActiveLabel.framework */; };
 		8F0249B21B9989B1005D8035 /* ActiveTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0249B11B9989B1005D8035 /* ActiveTypeTests.swift */; };
@@ -56,6 +57,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		786936A622200FAD00E52AC5 /* ActiveLabelHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveLabelHandler.swift; sourceTree = "<group>"; };
 		8F0249A21B9989B1005D8035 /* ActiveLabel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ActiveLabel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F0249A51B9989B1005D8035 /* ActiveLabel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActiveLabel.h; sourceTree = "<group>"; };
 		8F0249A71B9989B1005D8035 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 		8F0249A41B9989B1005D8035 /* ActiveLabel */ = {
 			isa = PBXGroup;
 			children = (
+				786936A622200FAD00E52AC5 /* ActiveLabelHandler.swift */,
 				8F0249A51B9989B1005D8035 /* ActiveLabel.h */,
 				8F0249D41B998D21005D8035 /* ActiveType.swift */,
 				8F0249D21B998C00005D8035 /* ActiveLabel.swift */,
@@ -310,6 +313,7 @@
 				8F0249D51B998D21005D8035 /* ActiveType.swift in Sources */,
 				C1D15C7B1D7C9B7E0041D119 /* ActiveBuilder.swift in Sources */,
 				C1E867D61C3D7AEA00FD687A /* RegexParser.swift in Sources */,
+				786936A722200FAE00E52AC5 /* ActiveLabelHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ActiveLabel.xcodeproj/project.pbxproj
+++ b/ActiveLabel.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		786936A722200FAE00E52AC5 /* ActiveLabelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786936A622200FAD00E52AC5 /* ActiveLabelHandler.swift */; };
+		786936A922200FE100E52AC5 /* ActiveLabelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786936A822200FE100E52AC5 /* ActiveLabelHandlerTests.swift */; };
 		8F0249A61B9989B1005D8035 /* ActiveLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F0249A51B9989B1005D8035 /* ActiveLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8F0249AD1B9989B1005D8035 /* ActiveLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0249A21B9989B1005D8035 /* ActiveLabel.framework */; };
 		8F0249B21B9989B1005D8035 /* ActiveTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0249B11B9989B1005D8035 /* ActiveTypeTests.swift */; };
@@ -58,6 +59,7 @@
 
 /* Begin PBXFileReference section */
 		786936A622200FAD00E52AC5 /* ActiveLabelHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveLabelHandler.swift; sourceTree = "<group>"; };
+		786936A822200FE100E52AC5 /* ActiveLabelHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveLabelHandlerTests.swift; sourceTree = "<group>"; };
 		8F0249A21B9989B1005D8035 /* ActiveLabel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ActiveLabel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F0249A51B9989B1005D8035 /* ActiveLabel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActiveLabel.h; sourceTree = "<group>"; };
 		8F0249A71B9989B1005D8035 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 		8F0249B01B9989B1005D8035 /* ActiveLabelTests */ = {
 			isa = PBXGroup;
 			children = (
+				786936A822200FE100E52AC5 /* ActiveLabelHandlerTests.swift */,
 				8F0249B11B9989B1005D8035 /* ActiveTypeTests.swift */,
 				8F0249B31B9989B1005D8035 /* Info.plist */,
 			);
@@ -322,6 +325,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8F0249B21B9989B1005D8035 /* ActiveTypeTests.swift in Sources */,
+				786936A922200FE100E52AC5 /* ActiveLabelHandlerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ActiveLabel/ActiveLabelHandler.swift
+++ b/ActiveLabel/ActiveLabelHandler.swift
@@ -1,0 +1,92 @@
+//
+//  ActiveLabelHandler.swift
+//  ActiveLabel
+//
+//  Created by Viktor Kalinchuk on 2/22/19.
+//  Copyright © 2019 Optonaut. All rights reserved.
+//
+
+import Foundation
+
+typealias HandlerResult = (handled: Bool, selectedText: String)
+
+class ActiveLabelHandler {
+
+    var mentionTapHandler: ((String) -> ())?
+    var hashtagTapHandler: ((String) -> ())?
+    var urlTapHandler: ((URL) -> ())?
+    var customTapHandlers: [ActiveType : ((String) -> ())] = [:]
+
+    func handle(selectedElement: ElementTuple) -> HandlerResult {
+        switch selectedElement.element {
+        case .mention(let userHandle):
+            return handle(mention: userHandle)
+        case .hashtag(let hashtag):
+            return handle(hashtag: hashtag)
+        case .url(let originalURL, _):
+            return handle(stringURL: originalURL)
+        case .custom(let element):
+            return handle(element: element, for: selectedElement.type)
+        }
+    }
+
+    func removeHandler(for type: ActiveType) {
+        switch type {
+        case .hashtag:
+            hashtagTapHandler = nil
+        case .mention:
+            mentionTapHandler = nil
+        case .url:
+            urlTapHandler = nil
+        case .custom:
+            customTapHandlers[type] = nil
+        }
+    }
+
+    func removeAllHandlers() {
+        hashtagTapHandler = nil
+        mentionTapHandler = nil
+        urlTapHandler = nil
+        customTapHandlers.removeAll()
+    }
+
+    // MARK: - Private methods
+
+    private func handle(mention username: String) -> HandlerResult {
+        guard let mentionHandler = mentionTapHandler else {
+            return (handled: false, selectedText: username)
+        }
+
+        mentionHandler(username)
+        return (handled: true, selectedText: username)
+    }
+
+    private func handle(hashtag: String) -> HandlerResult {
+        guard let hashtagHandler = hashtagTapHandler else {
+            return (handled: false, selectedText: hashtag)
+        }
+
+        hashtagHandler(hashtag)
+        return (handled: true, selectedText: hashtag)
+    }
+
+    private func handle(stringURL: String) -> HandlerResult {
+        let escaped = stringURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        guard let urlHandler = urlTapHandler, let url = escaped.flatMap(URL.init(string:)) else {
+            return (handled: false, selectedText: stringURL)
+        }
+
+        urlHandler(url)
+        return (handled: true, selectedText: stringURL)
+    }
+
+    private func handle(element: String, for type: ActiveType) -> HandlerResult {
+        guard let elementHandler = customTapHandlers[type] else {
+            return (handled: false, selectedText: element)
+        }
+
+        elementHandler(element)
+        return (handled: true, selectedText: element)
+    }
+
+}

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -24,11 +24,11 @@ class ViewController: UIViewController {
         label.enabledTypes.append(customType2)
         label.enabledTypes.append(customType3)
 
-        label.urlMaximumLength = 31
+        label.urlMaximumLength = 35
 
         label.customize { label in
             label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like" +
-            " this one: http://optonaut.co. Now it also supports custom patterns -> are\n\n" +
+            " this one: http://optonaut.co. Automatic URL escaping also works, check out https://ko.wikipedia.org/wiki/위키백과:대문 \nNow it also supports custom patterns -> are\n\n" +
                 "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601"
             label.numberOfLines = 0
             label.lineSpacing = 4

--- a/ActiveLabelTests/ActiveLabelHandlerTests.swift
+++ b/ActiveLabelTests/ActiveLabelHandlerTests.swift
@@ -1,0 +1,130 @@
+//
+//  ActiveLabelHandlerTests.swift
+//  ActiveLabelTests
+//
+//  Created by Viktor Kalinchuk on 2/22/19.
+//  Copyright © 2019 Optonaut. All rights reserved.
+//
+
+import XCTest
+@testable import ActiveLabel
+
+class ActiveLabelHandlerTests: XCTestCase {
+
+    func testHandleMentionHandlerNotSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.mention
+        let element = ActiveElement.create(with: type, text: "@somebody")
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertFalse(result.handled)
+        XCTAssertEqual(result.selectedText, "@somebody")
+    }
+
+    func testHandleMentionHandlerSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.mention
+        let element = ActiveElement.create(with: type, text: "@somebody")
+
+        var handlerInvokationCount = 0
+        handler.mentionTapHandler = { _ in
+            handlerInvokationCount += 1
+        }
+
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertTrue(result.handled)
+        XCTAssertEqual(result.selectedText, "@somebody")
+        XCTAssertEqual(handlerInvokationCount, 1)
+    }
+
+    func testHandleHashtagHandlerNotSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.hashtag
+        let element = ActiveElement.create(with: type, text: "#look")
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertFalse(result.handled)
+        XCTAssertEqual(result.selectedText, "#look")
+    }
+
+    func testHandleHashtagHandlerSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.hashtag
+        let element = ActiveElement.create(with: type, text: "#look")
+
+        var handlerInvokationCount = 0
+        handler.hashtagTapHandler = { _ in
+            handlerInvokationCount += 1
+        }
+
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertTrue(result.handled)
+        XCTAssertEqual(result.selectedText, "#look")
+        XCTAssertEqual(handlerInvokationCount, 1)
+    }
+
+    func testHandleURLHandlerNotSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.url
+        let element = ActiveElement.create(with: type, text: "https://google.com")
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertFalse(result.handled)
+        XCTAssertEqual(result.selectedText, "https://google.com")
+    }
+
+    func testHandleValidURLHandlerSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.url
+        let element = ActiveElement.create(with: type, text: "https://google.com")
+
+        var handlerInvokationCount = 0
+        handler.urlTapHandler = { _ in
+            handlerInvokationCount += 1
+        }
+
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertTrue(result.handled)
+        XCTAssertEqual(result.selectedText, "https://google.com")
+        XCTAssertEqual(handlerInvokationCount, 1)
+    }
+
+    // Tests a case, when URL creation with supplied string is impossible
+    func testHandleInvalidURLHandlerSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.url
+        let element = ActiveElement.create(with: type, text: "")
+
+        var handlerInvokationCount = 0
+        handler.urlTapHandler = { _ in
+            handlerInvokationCount += 1
+        }
+
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertFalse(result.handled)
+        XCTAssertEqual(result.selectedText, "")
+        XCTAssertEqual(handlerInvokationCount, 0)
+    }
+
+    func testHandleURLEscapingHandlerSet() {
+        let handler = ActiveLabelHandler()
+        let type = ActiveType.url
+        let element = ActiveElement.create(with: type, text: "https://ko.wikipedia.org/wiki/위키백과:대문")
+
+        var handlerInvokationCount = 0
+        handler.urlTapHandler = { _ in
+            handlerInvokationCount += 1
+        }
+
+        let result = handler.handle(selectedElement: (range: NSRange(location: 0, length: 1), element: element, type: type))
+
+        XCTAssertTrue(result.handled)
+        XCTAssertEqual(result.selectedText, "https://ko.wikipedia.org/wiki/위키백과:대문")
+        XCTAssertEqual(handlerInvokationCount, 1)
+    }
+
+}

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -58,6 +58,7 @@ class ActiveTypeTests: XCTestCase {
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
+        label.removeAllHandlers()
         super.tearDown()
     }
     
@@ -256,41 +257,64 @@ class ActiveTypeTests: XCTestCase {
 
     func testRemoveHandleMention() {
         label.handleMentionTap({_ in })
-        XCTAssertNotNil(label.handleMentionTap)
-        
-        label.removeHandle(for: .mention)
-        XCTAssertNil(label.mentionTapHandler)
+        XCTAssertNotNil(label.handler.mentionTapHandler)
+
+        label.removeHandler(for: .mention)
+        XCTAssertNil(label.handler.mentionTapHandler)
     }
-    
+
     func testRemoveHandleHashtag() {
         label.handleHashtagTap({_ in })
-        XCTAssertNotNil(label.handleHashtagTap)
-        
-        label.removeHandle(for: .hashtag)
-        XCTAssertNil(label.hashtagTapHandler)
+        XCTAssertNotNil(label.handler.hashtagTapHandler)
+
+        label.removeHandler(for: .hashtag)
+        XCTAssertNil(label.handler.hashtagTapHandler)
     }
-    
+
     func testRemoveHandleURL() {
         label.handleURLTap({_ in })
-        XCTAssertNotNil(label.handleURLTap)
-        
-        label.removeHandle(for: .url)
-        XCTAssertNil(label.urlTapHandler)
+        XCTAssertNotNil(label.handler.urlTapHandler)
+
+        label.removeHandler(for: .url)
+        XCTAssertNil(label.handler.urlTapHandler)
     }
-    
+
     func testRemoveHandleCustom() {
         let newType1 = ActiveType.custom(pattern: "\\sare1\\b")
         let newType2 = ActiveType.custom(pattern: "\\sare2\\b")
-        
+
         label.handleCustomTap(for: newType1, handler: {_ in })
         label.handleCustomTap(for: newType2, handler: {_ in })
-        XCTAssertEqual(label.customTapHandlers.count, 2)
-        
-        label.removeHandle(for: newType1)
-        XCTAssertEqual(label.customTapHandlers.count, 1)
-        
-        label.removeHandle(for: newType2)
-        XCTAssertEqual(label.customTapHandlers.count, 0)
+        XCTAssertEqual(label.handler.customTapHandlers.count, 2)
+
+        label.removeHandler(for: newType1)
+        XCTAssertEqual(label.handler.customTapHandlers.count, 1)
+
+        label.removeHandler(for: newType2)
+        XCTAssertEqual(label.handler.customTapHandlers.count, 0)
+    }
+
+    func testRemoveAllHandlers() {
+        let label = ActiveLabel()
+        label.handleMentionTap({_ in })
+        label.handleHashtagTap({_ in })
+        label.handleURLTap({_ in })
+
+        let newType1 = ActiveType.custom(pattern: "\\sare1\\b")
+        let newType2 = ActiveType.custom(pattern: "\\sare2\\b")
+        label.handleCustomTap(for: newType1, handler: {_ in })
+        label.handleCustomTap(for: newType2, handler: {_ in })
+
+        XCTAssertNotNil(label.handler.mentionTapHandler)
+        XCTAssertNotNil(label.handler.hashtagTapHandler)
+        XCTAssertNotNil(label.handler.urlTapHandler)
+        XCTAssertEqual(label.handler.customTapHandlers.count, 2)
+
+        label.removeAllHandlers()
+        XCTAssertNil(label.handler.mentionTapHandler)
+        XCTAssertNil(label.handler.hashtagTapHandler)
+        XCTAssertNil(label.handler.urlTapHandler)
+        XCTAssertEqual(label.handler.customTapHandlers.count, 0)
     }
 
     func testFiltering() {


### PR DESCRIPTION
### Background:

I faced with a problem with an URL, containing cyrillic symbols. Tap on a link like https://ru.wikipedia.org/wiki/Толстой,_Лев_Николаевич inside ActiveLabel does not invoke **handleURLTap** closure. 

### Reason
The reason that **ActiveLabel** doesn't add percent encoding to the supplied string before converting it to an URL.

### Solution
There is an old pull request #131, raised few years ago. It solves the problem by adding percent encoding, but there was a problem to cover the fix with unit tests, because the logic is inside the **ActiveLabel** class. So the PR is still unmerged.

I moved handling logic into a separate object to make it testable and added needed unit tests.

Changes list:
- Added a link with hieroglyphs to the demo app to expose the problem.
- Created a separate class **ActiveLabelHandler** and moved active element handling logic into it.
- Created a function to remove all handlers to the **ActiveLabel** (required for unit test, otherwise they may have unpredictable results under certain circumstances).
- Updated tests for **ActiveLabel**.
- Added tests for **ActiveLabelHandler**.