### PR TITLE
Fix for attributed string attributes loss with length checks

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -277,6 +277,11 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             clearActiveElements()
             let newString = parseTextAndExtractActiveElements(mutAttrString)
             mutAttrString.mutableString.setString(newString)
+            let range = (attributedText.string as NSString).range(of: newString)
+            attributedText.enumerateAttributes(in: range,
+                                               options: .longestEffectiveRangeNotRequired, using: { (attribute, range, stop) in
+                mutAttrString.addAttributes(attribute, range: range)
+            })
         }
 
         addLinkAttribute(mutAttrString)


### PR DESCRIPTION
Fixed NSAttributedString setString issue that removes original attributes by enumerating the original attributes and copying them to the new element

this PR should fix #219