### PR TITLE
Updated mention and hashtag regular expressions

### DIFF
--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -10,8 +10,8 @@ import Foundation
 
 struct RegexParser {
 
-    static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"
-    static let mentionPattern = "(?:^|\\s|$|[.])@[\\p{L}0-9_]*"
+    static let hashtagPattern = "(?<=^|\\s|$|\\.)#[\\p{L}\\d_]*"
+    static let mentionPattern = "(?<=^|\\s|$|\\.)@[\\p{L}\\d_]*"
     static let urlPattern = "(^|[\\s.:;?\\-\\]<\\(])" +
         "((https?://|www\\.|pic\\.)[-\\w;/?:@&=+$\\|\\_.!~*\\|'()\\[\\]%#,☺]+[\\w/#](\\(\\))?)" +
     "(?=$|[\\s',\\|\\(\\).:;?\\-\\[\\]>\\)])"


### PR DESCRIPTION
I updated the mention and hashtag regular expressions to not capture the prefixing character (` `, `.`, etc).