### PR TITLE
Added in missing cases for new UITouchPhases, iOS 13.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.2
+osx_image: xcode11.4
 before_install:
 - gem install bundler
 - gem update bundler

--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -193,7 +193,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
         var avoidSuperCall = false
         
         switch touch.phase {
-        case .began, .moved:
+        case .began, .moved, .regionEntered, .regionMoved:
             if let element = element(at: location) {
                 if element.range.location != selectedElement?.range.location || element.range.length != selectedElement?.range.length {
                     updateAttributesWhenSelected(false)
@@ -205,7 +205,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
                 updateAttributesWhenSelected(false)
                 selectedElement = nil
             }
-        case .ended:
+        case .ended, .regionExited:
             guard let selectedElement = selectedElement else { return avoidSuperCall }
             
             switch selectedElement.element {


### PR DESCRIPTION
There are three new phases added in iOS 13.4. They are:

`.regionEntered .regionMoved .regionExited`

These need to be accounted for in the switch statement when handling touches.