### PR TITLE
Support for only using the value of a capture group as active element

### DIFF
--- a/ActiveLabel/ActiveBuilder.swift
+++ b/ActiveLabel/ActiveBuilder.swift
@@ -64,11 +64,11 @@ struct ActiveBuilder {
         var elements: [ElementTuple] = []
 
         for match in matches where match.range.length > minLength {
-            let word = nsstring.substring(with: match.range)
+            let word = nsstring.substring(with: match.range(at: type.captureGroup))
                 .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             if filterPredicate?(word) ?? true {
                 let element = ActiveElement.create(with: type, text: word)
-                elements.append((match.range, element, type))
+                elements.append((match.range(at: type.captureGroup), element, type))
             }
         }
         return elements

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -31,7 +31,7 @@ public enum ActiveType {
     case hashtag
     case url
     case email
-    case custom(pattern: String)
+    case custom(pattern: String, captureGroup: Int = 0)
     
     var pattern: String {
         switch self {
@@ -39,7 +39,14 @@ public enum ActiveType {
         case .hashtag: return RegexParser.hashtagPattern
         case .url: return RegexParser.urlPattern
         case .email: return RegexParser.emailPattern
-        case .custom(let regex): return regex
+        case .custom(let regex, _): return regex
+        }
+    }
+    
+    var captureGroup: Int {
+        switch self {
+        case .custom(_, let captureGroup): return captureGroup
+        default: return 0
         }
     }
 }
@@ -51,7 +58,7 @@ extension ActiveType: Hashable, Equatable {
         case .hashtag: hasher.combine(-2)
         case .url: hasher.combine(-3)
         case .email: hasher.combine(-4)
-        case .custom(let regex): hasher.combine(regex)
+        case .custom(let regex, _): hasher.combine(regex)
         }
     }
 }

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -225,6 +225,29 @@ class ActiveTypeTests: XCTestCase {
         XCTAssertEqual(activeElements.count, 0)
     }
     
+    func testCustomTypeCaptureGroup() {
+        let newType = ActiveType.custom(pattern: "\\s(are).*", captureGroup: 1)
+        label.enabledTypes.append(newType)
+
+        label.text = "we are one"
+        XCTAssertEqual(activeElements.count, 1)
+        XCTAssertEqual(currentElementString, "are")
+        XCTAssertEqual(currentElementType, customEmptyType)
+
+        label.text = "are. are"
+        XCTAssertEqual(activeElements.count, 1)
+        XCTAssertEqual(currentElementString, "are")
+        XCTAssertEqual(currentElementType, customEmptyType)
+
+        label.text = "helloare are"
+        XCTAssertEqual(activeElements.count, 1)
+        XCTAssertEqual(currentElementString, "are")
+        XCTAssertEqual(currentElementType, customEmptyType)
+
+        label.text = "google"
+        XCTAssertEqual(activeElements.count, 0)
+    }
+    
     func testConfigureLinkAttributes() {
         // Customize label
         let newType = ActiveType.custom(pattern: "\\sare\\b")


### PR DESCRIPTION
Hi,

we had the requirement that we wanted to use a custom regex in `ActiveLabel.swift` with the special situation that we only wanted a capture group to be active. This pull request adds the captureGroup parameter to `ActiveType.custom`. It is an optional parameter so that existing setups don't get broken. Feel free to request any changes to this PR.

Best regards,
Yannik