### PR TITLE
Update ActiveLabel.swift

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -438,7 +438,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             attributes = configureLinkAttribute(type, attributes, isSelected)
         }
         
-        textStorage.addAttributes(attributes, range: selectedElement.range)
+        textStorage.setAttributes(attributes, range: selectedElement.range)
         
         setNeedsDisplay()
     }


### PR DESCRIPTION
Fix a bug. Font (bold or fontSize) which set on Element will disappear after select.