### PR TITLE
Add phone, date, and address parsing support

### DIFF
--- a/ActiveLabel.xcodeproj/project.pbxproj
+++ b/ActiveLabel.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		8F0249A61B9989B1005D8035 /* ActiveLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F0249A51B9989B1005D8035 /* ActiveLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8F0249AD1B9989B1005D8035 /* ActiveLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0249A21B9989B1005D8035 /* ActiveLabel.framework */; };
-		8F0249B21B9989B1005D8035 /* ActiveTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0249B11B9989B1005D8035 /* ActiveTypeTests.swift */; };
+		8F0249B21B9989B1005D8035 /* ActiveTypeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0249B11B9989B1005D8035 /* ActiveTypeIntegrationTests.swift */; };
 		8F0249C31B998A66005D8035 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0249C21B998A66005D8035 /* AppDelegate.swift */; };
 		8F0249C51B998A66005D8035 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0249C41B998A66005D8035 /* ViewController.swift */; };
 		8F0249C81B998A66005D8035 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8F0249C61B998A66005D8035 /* Main.storyboard */; };
@@ -22,6 +22,13 @@
 		C1E867D61C3D7AEA00FD687A /* RegexParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E867D51C3D7AEA00FD687A /* RegexParser.swift */; };
 		E267FA251DB3A34900EEAC4C /* ActiveLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0249A21B9989B1005D8035 /* ActiveLabel.framework */; };
 		E267FA261DB3A34900EEAC4C /* ActiveLabel.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0249A21B9989B1005D8035 /* ActiveLabel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FFACB85E268BBCB3002639FE /* PhoneParsingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFACB85D268BBCB3002639FE /* PhoneParsingIntegrationTests.swift */; };
+		FFACB862268BD641002639FE /* BaseIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFACB861268BD641002639FE /* BaseIntegrationTestCase.swift */; };
+		FFACB86E268BF308002639FE /* AddressParsingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFACB86D268BF308002639FE /* AddressParsingIntegrationTests.swift */; };
+		FFACB872268BF495002639FE /* DateParsingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFACB871268BF495002639FE /* DateParsingIntegrationTests.swift */; };
+		FFF0FEBD26950ED300AC7B37 /* ActiveElement+UnitTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF0FEBC26950ED300AC7B37 /* ActiveElement+UnitTestUtilities.swift */; };
+		FFF0FEC726950F5D00AC7B37 /* ActiveLabelUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF0FEC626950F5D00AC7B37 /* ActiveLabelUnitTests.swift */; };
+		FFF0FECC269510E300AC7B37 /* MockActiveBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF0FECB269510E300AC7B37 /* MockActiveBuilder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,7 +67,7 @@
 		8F0249A51B9989B1005D8035 /* ActiveLabel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActiveLabel.h; sourceTree = "<group>"; };
 		8F0249A71B9989B1005D8035 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8F0249AC1B9989B1005D8035 /* ActiveLabelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ActiveLabelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8F0249B11B9989B1005D8035 /* ActiveTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveTypeTests.swift; sourceTree = "<group>"; };
+		8F0249B11B9989B1005D8035 /* ActiveTypeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveTypeIntegrationTests.swift; sourceTree = "<group>"; };
 		8F0249B31B9989B1005D8035 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8F0249C01B998A66005D8035 /* ActiveLabelDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ActiveLabelDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F0249C21B998A66005D8035 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -74,6 +81,13 @@
 		C1D15C781D7C9B610041D119 /* StringTrimExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTrimExtension.swift; sourceTree = "<group>"; };
 		C1D15C7A1D7C9B7E0041D119 /* ActiveBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveBuilder.swift; sourceTree = "<group>"; };
 		C1E867D51C3D7AEA00FD687A /* RegexParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexParser.swift; sourceTree = "<group>"; };
+		FFACB85D268BBCB3002639FE /* PhoneParsingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneParsingIntegrationTests.swift; sourceTree = "<group>"; };
+		FFACB861268BD641002639FE /* BaseIntegrationTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseIntegrationTestCase.swift; sourceTree = "<group>"; };
+		FFACB86D268BF308002639FE /* AddressParsingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressParsingIntegrationTests.swift; sourceTree = "<group>"; };
+		FFACB871268BF495002639FE /* DateParsingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateParsingIntegrationTests.swift; sourceTree = "<group>"; };
+		FFF0FEBC26950ED300AC7B37 /* ActiveElement+UnitTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActiveElement+UnitTestUtilities.swift"; sourceTree = "<group>"; };
+		FFF0FEC626950F5D00AC7B37 /* ActiveLabelUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveLabelUnitTests.swift; sourceTree = "<group>"; };
+		FFF0FECB269510E300AC7B37 /* MockActiveBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockActiveBuilder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,8 +154,11 @@
 		8F0249B01B9989B1005D8035 /* ActiveLabelTests */ = {
 			isa = PBXGroup;
 			children = (
-				8F0249B11B9989B1005D8035 /* ActiveTypeTests.swift */,
+				FFF0FECA269510CF00AC7B37 /* Mocks */,
+				FFF0FEB126950E6700AC7B37 /* IntegrationTests */,
 				8F0249B31B9989B1005D8035 /* Info.plist */,
+				FFF0FEBC26950ED300AC7B37 /* ActiveElement+UnitTestUtilities.swift */,
+				FFF0FEC626950F5D00AC7B37 /* ActiveLabelUnitTests.swift */,
 			);
 			path = ActiveLabelTests;
 			sourceTree = "<group>";
@@ -157,6 +174,26 @@
 				8F0249CE1B998A66005D8035 /* Info.plist */,
 			);
 			path = ActiveLabelDemo;
+			sourceTree = "<group>";
+		};
+		FFF0FEB126950E6700AC7B37 /* IntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				FFACB861268BD641002639FE /* BaseIntegrationTestCase.swift */,
+				8F0249B11B9989B1005D8035 /* ActiveTypeIntegrationTests.swift */,
+				FFACB85D268BBCB3002639FE /* PhoneParsingIntegrationTests.swift */,
+				FFACB86D268BF308002639FE /* AddressParsingIntegrationTests.swift */,
+				FFACB871268BF495002639FE /* DateParsingIntegrationTests.swift */,
+			);
+			path = IntegrationTests;
+			sourceTree = "<group>";
+		};
+		FFF0FECA269510CF00AC7B37 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				FFF0FECB269510E300AC7B37 /* MockActiveBuilder.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -317,7 +354,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8F0249B21B9989B1005D8035 /* ActiveTypeTests.swift in Sources */,
+				8F0249B21B9989B1005D8035 /* ActiveTypeIntegrationTests.swift in Sources */,
+				FFF0FEC726950F5D00AC7B37 /* ActiveLabelUnitTests.swift in Sources */,
+				FFACB86E268BF308002639FE /* AddressParsingIntegrationTests.swift in Sources */,
+				FFACB872268BF495002639FE /* DateParsingIntegrationTests.swift in Sources */,
+				FFF0FEBD26950ED300AC7B37 /* ActiveElement+UnitTestUtilities.swift in Sources */,
+				FFACB862268BD641002639FE /* BaseIntegrationTestCase.swift in Sources */,
+				FFACB85E268BBCB3002639FE /* PhoneParsingIntegrationTests.swift in Sources */,
+				FFF0FECC269510E300AC7B37 /* MockActiveBuilder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ActiveLabel/ActiveBuilder.swift
+++ b/ActiveLabel/ActiveBuilder.swift
@@ -10,59 +10,68 @@ import Foundation
 
 typealias ActiveFilterPredicate = ((String) -> Bool)
 
-struct ActiveBuilder {
+protocol ActiveBuilderInterface {
+    func createElements(type: ActiveType, from text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [ElementTuple]
+    func createURLElements(from text: String, range: NSRange, maximumLength: Int?) -> ([ElementTuple], String)
+}
 
-    static func createElements(type: ActiveType, from text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
+final class ActiveBuilder: ActiveBuilderInterface {
+    
+    private let regexParser: RegexParserInterface
+    
+    init(regexParser: RegexParserInterface) {
+        self.regexParser = regexParser
+    }
+    
+    func createElements(type: ActiveType, from text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
         switch type {
         case .mention, .hashtag:
             return createElementsIgnoringFirstCharacter(from: text, for: type, range: range, filterPredicate: filterPredicate)
-        case .url:
+        case .url, .email, .phone, .address, .date:
             return createElements(from: text, for: type, range: range, filterPredicate: filterPredicate)
         case .custom:
             return createElements(from: text, for: type, range: range, minLength: 1, filterPredicate: filterPredicate)
-        case .email:
-            return createElements(from: text, for: type, range: range, filterPredicate: filterPredicate)
         }
     }
-
-    static func createURLElements(from text: String, range: NSRange, maximumLength: Int?) -> ([ElementTuple], String) {
+    
+    func createURLElements(from text: String, range: NSRange, maximumLength: Int?) -> ([ElementTuple], String) {
         let type = ActiveType.url
         var text = text
-        let matches = RegexParser.getElements(from: text, with: type.pattern, range: range)
+        let matches = regexParser.getElements(from: text, with: type, range: range)
         let nsstring = text as NSString
         var elements: [ElementTuple] = []
-
+        
         for match in matches where match.range.length > 2 {
             let word = nsstring.substring(with: match.range)
                 .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-
+            
             guard let maxLength = maximumLength, word.count > maxLength else {
                 let range = maximumLength == nil ? match.range : (text as NSString).range(of: word)
                 let element = ActiveElement.create(with: type, text: word)
                 elements.append((range, element, type))
                 continue
             }
-
+            
             let trimmedWord = word.trim(to: maxLength)
             text = text.replacingOccurrences(of: word, with: trimmedWord)
-
+            
             let newRange = (text as NSString).range(of: trimmedWord)
             let element = ActiveElement.url(original: word, trimmed: trimmedWord)
             elements.append((newRange, element, type))
         }
         return (elements, text)
     }
-
-    private static func createElements(from text: String,
-                                            for type: ActiveType,
-                                                range: NSRange,
-                                                minLength: Int = 2,
-                                                filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
-
-        let matches = RegexParser.getElements(from: text, with: type.pattern, range: range)
+    
+    private func createElements(from text: String,
+                                for type: ActiveType,
+                                range: NSRange,
+                                minLength: Int = 2,
+                                filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
+        
+        let matches = regexParser.getElements(from: text, with: type, range: range)
         let nsstring = text as NSString
         var elements: [ElementTuple] = []
-
+        
         for match in matches where match.range.length > minLength {
             let word = nsstring.substring(with: match.range)
                 .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
@@ -73,15 +82,15 @@ struct ActiveBuilder {
         }
         return elements
     }
-
-    private static func createElementsIgnoringFirstCharacter(from text: String,
-                                                                  for type: ActiveType,
-                                                                      range: NSRange,
-                                                                      filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
-        let matches = RegexParser.getElements(from: text, with: type.pattern, range: range)
+    
+    private func createElementsIgnoringFirstCharacter(from text: String,
+                                                      for type: ActiveType,
+                                                      range: NSRange,
+                                                      filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
+        let matches = regexParser.getElements(from: text, with: type, range: range)
         let nsstring = text as NSString
         var elements: [ElementTuple] = []
-
+        
         for match in matches where match.range.length > 2 {
             let range = NSRange(location: match.range.location + 1, length: match.range.length - 1)
             var word = nsstring.substring(with: range)
@@ -91,7 +100,7 @@ struct ActiveBuilder {
             else if word.hasPrefix("#") {
                 word.remove(at: word.startIndex)
             }
-
+            
             if filterPredicate?(word) ?? true {
                 let element = ActiveElement.create(with: type, text: word)
                 elements.append((match.range, element, type))

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -13,6 +13,9 @@ enum ActiveElement {
     case hashtag(String)
     case email(String)
     case url(original: String, trimmed: String)
+    case phone(String)
+    case address(String)
+    case date(String)
     case custom(String)
     
     static func create(with activeType: ActiveType, text: String) -> ActiveElement {
@@ -20,7 +23,10 @@ enum ActiveElement {
         case .mention: return mention(text)
         case .hashtag: return hashtag(text)
         case .email: return email(text)
+        case .phone: return phone(text)
         case .url: return url(original: text, trimmed: text)
+        case .address: return address(text)
+        case .date: return date(text)
         case .custom: return custom(text)
         }
     }
@@ -31,26 +37,23 @@ public enum ActiveType {
     case hashtag
     case url
     case email
+    case phone
+    case address
+    case date
     case custom(pattern: String)
-    
-    var pattern: String {
-        switch self {
-        case .mention: return RegexParser.mentionPattern
-        case .hashtag: return RegexParser.hashtagPattern
-        case .url: return RegexParser.urlPattern
-        case .email: return RegexParser.emailPattern
-        case .custom(let regex): return regex
-        }
-    }
 }
 
 extension ActiveType: Hashable, Equatable {
+    /// NOTE: this is for using it as a key in dictionaries
     public func hash(into hasher: inout Hasher) {
         switch self {
         case .mention: hasher.combine(-1)
         case .hashtag: hasher.combine(-2)
         case .url: hasher.combine(-3)
         case .email: hasher.combine(-4)
+        case .phone: hasher.combine(-5)
+        case .address: hasher.combine(-6)
+        case .date: hasher.combine(-7)
         case .custom(let regex): hasher.combine(regex)
         }
     }
@@ -62,6 +65,9 @@ public func ==(lhs: ActiveType, rhs: ActiveType) -> Bool {
     case (.hashtag, .hashtag): return true
     case (.url, .url): return true
     case (.email, .email): return true
+    case (.phone, .phone): return true
+    case (.address, .address): return true
+    case (.date, .date): return true
     case (.custom(let pattern1), .custom(let pattern2)): return pattern1 == pattern2
     default: return false
     }

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -23,13 +23,19 @@ class ViewController: UIViewController {
         label.enabledTypes.append(customType)
         label.enabledTypes.append(customType2)
         label.enabledTypes.append(customType3)
+        label.enabledTypes.append(.phone)
+        label.enabledTypes.append(.address)
+        label.enabledTypes.append(.date)
 
         label.urlMaximumLength = 31
 
         label.customize { label in
             label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like" +
             " this one: http://optonaut.co. Now it also supports custom patterns -> are\n\n" +
-                "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601"
+                "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601" +
+                "\nPlus it has phone number +1-202-555-0116 support now" +
+                "\n Address support: 123 Some Awesome St., Katy, TX 12345" +
+                "\n Date support: June 30th, 2021"
             label.numberOfLines = 0
             label.lineSpacing = 4
             
@@ -38,10 +44,15 @@ class ViewController: UIViewController {
             label.mentionColor = UIColor(red: 238.0/255, green: 85.0/255, blue: 96.0/255, alpha: 1)
             label.URLColor = UIColor(red: 85.0/255, green: 238.0/255, blue: 151.0/255, alpha: 1)
             label.URLSelectedColor = UIColor(red: 82.0/255, green: 190.0/255, blue: 41.0/255, alpha: 1)
+            label.phoneColor = .purple
+            label.phoneSelectedColor = .green
 
             label.handleMentionTap { self.alert("Mention", message: $0) }
             label.handleHashtagTap { self.alert("Hashtag", message: $0) }
             label.handleURLTap { self.alert("URL", message: $0.absoluteString) }
+            label.handlePhoneTap { self.alert("Phone", message: $0) }
+            label.handleAddressTap { self.alert("Address", message: $0) }
+            label.handleDateTap { self.alert("Date", message: $0) }
 
             //Custom types
 

--- a/ActiveLabelTests/ActiveElement+UnitTestUtilities.swift
+++ b/ActiveLabelTests/ActiveElement+UnitTestUtilities.swift
@@ -1,0 +1,26 @@
+//
+//  ActiveElement+UnitTestUtilities.swift
+//  ActiveLabelTests
+//
+//  Created by Alex Bush | Upkeep on 7/6/21.
+//  Copyright © 2021 Optonaut. All rights reserved.
+//
+
+import Foundation
+
+@testable import ActiveLabel
+
+extension ActiveElement: Equatable {}
+
+public func ==(a: ActiveElement, b: ActiveElement) -> Bool {
+    switch (a, b) {
+    case (.mention(let a), .mention(let b)) where a == b: return true
+    case (.hashtag(let a), .hashtag(let b)) where a == b: return true
+    case (.url(let a), .url(let b)) where a == b: return true
+    case (.custom(let a), .custom(let b)) where a == b: return true
+    case (.phone(let a), .phone(let b)) where a == b: return true
+    case (.address(let a), .address(let b)) where a == b: return true
+    case (.date(let a), .date(let b)) where a == b: return true
+    default: return false
+    }
+}

--- a/ActiveLabelTests/ActiveLabelUnitTests.swift
+++ b/ActiveLabelTests/ActiveLabelUnitTests.swift
@@ -1,0 +1,75 @@
+//
+//  ActiveLabelUnitTests.swift
+//  ActiveLabelTests
+//
+//  Created by Alex Bush | Upkeep on 7/6/21.
+//  Copyright © 2021 Optonaut. All rights reserved.
+//
+
+import XCTest
+@testable import ActiveLabel
+
+final class ActiveLabelUnitTests: XCTestCase {
+
+    func testItShouldParseTextForElementsWhenTextChanges() {
+        // given
+        let mockActiveBuilder = MockActiveBuilder()
+        let label = ActiveLabel(activeBuilder: mockActiveBuilder)
+        label.enabledTypes = [.mention, .hashtag, .url]
+        // when
+        label.text = "some text"
+        // then
+        XCTAssertEqual(mockActiveBuilder.createURLElementsCallCount, 1, "it should call url elements creation only once")
+        XCTAssertEqual(mockActiveBuilder.createElementsCallCount, 2, "it should call element creation for every other type of element besides url")
+    }
+    
+    func testItShouldCallElementsCreationUponTextChanges() {
+        // given
+        let mockActiveBuilder = MockActiveBuilder()
+        let label = ActiveLabel(activeBuilder: mockActiveBuilder)
+        label.enabledTypes = [.mention, .hashtag, .url]
+        // when
+        label.text = "something"
+        label.attributedText = NSAttributedString(string: "some other text")
+        label.filterMention { (string) -> Bool in return false }
+        label.filterHashtag { (string) -> Bool in return false }
+        label.awakeFromNib()
+        label.customize { (label) in }
+        // then
+        XCTAssertEqual(mockActiveBuilder.createURLElementsCallCount, 6, "it should call url elements creation only once per text change")
+        XCTAssertEqual(mockActiveBuilder.createElementsCallCount, 12, "it should call element creation for every other type of element besides url per text change")
+    }
+    
+    func testItShouldNotParseTextForElementsWhenTextDoesNotChange() {
+        // given
+        let mockActiveBuilder = MockActiveBuilder()
+        let label = ActiveLabel(activeBuilder: mockActiveBuilder)
+        label.enabledTypes = [.mention, .hashtag, .url]
+        // when
+        label.mentionColor = .black
+        label.mentionSelectedColor = .black
+        label.hashtagColor = .black
+        label.hashtagSelectedColor = .black
+        label.URLColor = .black
+        label.URLSelectedColor = .black
+        label.phoneColor = .black
+        label.phoneSelectedColor = .black
+        label.addressColor = .black
+        label.addressSelectedColor = .black
+        label.dateColor = .black
+        label.dateSelectedColor = .black
+        label.customColor = [.mention : .black]
+        label.customSelectedColor = [.mention : .black]
+        label.lineSpacing = 123.123
+        label.minimumLineHeight = 123.123
+        label.highlightFontName = nil
+        label.highlightFontSize = nil
+        label.font = UIFont()
+        label.textColor = .black
+        label.textAlignment = .center
+        // then
+        XCTAssertEqual(mockActiveBuilder.createURLElementsCallCount, 0)
+        XCTAssertEqual(mockActiveBuilder.createElementsCallCount, 0)
+    }
+
+}

--- a/ActiveLabelTests/IntegrationTests/ActiveTypeIntegrationTests.swift
+++ b/ActiveLabelTests/IntegrationTests/ActiveTypeIntegrationTests.swift
@@ -9,49 +9,8 @@
 import XCTest
 @testable import ActiveLabel
 
-extension ActiveElement: Equatable {}
+class ActiveTypeIntegrationTests: BaseIntegrationTestCase {
 
-public func ==(a: ActiveElement, b: ActiveElement) -> Bool {
-    switch (a, b) {
-    case (.mention(let a), .mention(let b)) where a == b: return true
-    case (.hashtag(let a), .hashtag(let b)) where a == b: return true
-    case (.url(let a), .url(let b)) where a == b: return true
-    case (.custom(let a), .custom(let b)) where a == b: return true
-    default: return false
-    }
-}
-
-class ActiveTypeTests: XCTestCase {
-    
-    let label = ActiveLabel()
-    let customEmptyType = ActiveType.custom(pattern: "")
-    
-    var activeElements: [ActiveElement] {
-        return label.activeElements.flatMap({$0.1.compactMap({$0.element})})
-    }
-    
-    var currentElementString: String? {
-        guard let currentElement = activeElements.first else { return nil }
-        switch currentElement {
-        case .mention(let mention): return mention
-        case .hashtag(let hashtag): return hashtag
-        case .url(let url, _): return url
-        case .custom(let element): return element
-        case .email(let element): return element
-        }
-    }
-    
-    var currentElementType: ActiveType? {
-        guard let currentElement = activeElements.first else { return nil }
-        switch currentElement {
-        case .mention: return .mention
-        case .hashtag: return .hashtag
-        case .url: return .url
-        case .custom: return customEmptyType
-        case .email: return .email
-        }
-    }
-    
     override func setUp() {
         super.setUp()
         label.enabledTypes = [.mention, .hashtag, .url]

--- a/ActiveLabelTests/IntegrationTests/AddressParsingIntegrationTests.swift
+++ b/ActiveLabelTests/IntegrationTests/AddressParsingIntegrationTests.swift
@@ -1,0 +1,91 @@
+//
+//  AddressParsingTests.swift
+//  ActiveLabelTests
+//
+//  Created by Alex Bush | Upkeep on 6/29/21.
+//  Copyright © 2021 Optonaut. All rights reserved.
+//
+
+import XCTest
+@testable import ActiveLabel
+
+final class AddressParsingIntegrationTests: BaseIntegrationTestCase {
+
+    // MARK: - BEGIN Parsing
+    func testItShouldNotRecognizeAnyAddressesInTextWithoutAddresses() {
+        // given
+        label.enabledTypes = [.address]
+        label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 0, "there shouldn't be any matches in a text that doesn't have any addresses in it")
+    }
+    
+    func testItShouldFindTheRightMatchesInTextWithAddresses() {
+        // given
+        let addressMock1 = "768 5th Ave"
+        let addressMock2 = "124 Some St, Houston, TX 12345"
+        label.enabledTypes = [.address]
+        label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation \(addressMock1) ullamco laboris nisi ut aliquip ex ea commodo consequat. \(addressMock2) Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 2, "there should be matches in a text that contains addresses")
+        let firstAddressMatch = activeElements[0]
+        if case .address(let addressText) = firstAddressMatch {
+            XCTAssertEqual(addressText, addressMock1)
+        } else {
+            XCTFail("first address should match")
+        }
+
+        let secondAddressMatch = activeElements[1]
+        if case .address(let addressText) = secondAddressMatch {
+            XCTAssertEqual(addressText, addressMock2)
+        } else {
+            XCTFail("second address should match")
+        }
+    }
+    
+    func testItShouldFindOnlyAddressMatchesInATextWithEmailPhoneAndOtherElementsGivenAddressAsTheOnlyEnabledType() {
+        // given
+        let addressMock1 = "768 5th Ave"
+        let addressMock2 = "124 Some St, Houston, TX 12345"
+        label.enabledTypes = [.address]
+        label.text = "Lorem ipsum dolor sit amet, @mention_of_something consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna \(addressMock1) aliqua. Ut #andahashtag enim ad minim veniam, quis email@somemail.com nostrud exercitation 202-555-0123 ullamco laboris nisi ut aliquip ex ea commodo consequat. +1-202-555-0116 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \(addressMock2) officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 2, "there should be matches in a text that contains addresses")
+    }
+    
+    func testItShouldFindAddressAndOtherMatchesInATextWithMultipleDifferentElements() {
+        // given
+        let addressMock1 = "768 5th Ave"
+        label.enabledTypes = [.mention, .hashtag, .email, .phone, .address]
+        label.text = "Lorem ipsum dolor sit amet, @mention_of_something consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut #andahashtag enim ad minim veniam, quis email@somemail.com nostrud exercitation 202-555-0123 ullamco laboris nisi ut aliquip ex ea commodo consequat. +1-202-555-0116 Duis aute irure dolor in reprehenderit \(addressMock1) in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 6, "there should be several different matches in a text that contains address and other elements")
+        XCTAssertEqual(activeElements(perType: .mention("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .hashtag("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .email("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .phone("")).count, 2)
+        XCTAssertEqual(activeElements(perType: .address("")).count, 1)
+    }
+    // MARK: END Parsing -
+
+    // MARK: - BEGIN Handler Removal
+    func testItRemovesAddressHandlerClosure() {
+        // given
+        label.handleAddressTap(handler: {_ in })
+        XCTAssertNotNil(label.handleAddressTap)
+        // when
+        label.removeHandle(for: .address)
+        // then
+        XCTAssertNil(label.addressTapHandler)
+    }
+    // MARK: END Handler Removal -
+
+}

--- a/ActiveLabelTests/IntegrationTests/BaseIntegrationTestCase.swift
+++ b/ActiveLabelTests/IntegrationTests/BaseIntegrationTestCase.swift
@@ -1,0 +1,79 @@
+//
+//  BaseTestCase.swift
+//  ActiveLabelTests
+//
+//  Created by Alex Bush | Upkeep on 6/29/21.
+//  Copyright © 2021 Optonaut. All rights reserved.
+//
+
+import XCTest
+@testable import ActiveLabel
+
+class BaseIntegrationTestCase: XCTestCase {
+    
+    var label: ActiveLabel!
+    
+    let customEmptyType = ActiveType.custom(pattern: "")
+    
+    var activeElements: [ActiveElement] {
+        return label.activeElements.flatMap({$0.1.compactMap({$0.element})})
+    }
+    
+    var currentElementString: String? {
+        guard let currentElement = activeElements.first else { return nil }
+        switch currentElement {
+        case .mention(let mention): return mention
+        case .hashtag(let hashtag): return hashtag
+        case .url(let url, _): return url
+        case .custom(let element): return element
+        case .email(let element): return element
+        case .phone(let element): return element
+        case .address(let element): return element
+        case .date(let element): return element
+        }
+    }
+    
+    var currentElementType: ActiveType? {
+        guard let currentElement = activeElements.first else { return nil }
+        switch currentElement {
+        case .mention: return .mention
+        case .hashtag: return .hashtag
+        case .url: return .url
+        case .custom: return customEmptyType
+        case .email: return .email
+        case .phone: return .phone
+        case .address: return .address
+        case .date: return .date
+        }
+    }
+    
+    override func setUp() {
+        super.setUp()
+        label = ActiveLabel()
+    }
+    
+    func activeElements(perType type: ActiveElement) -> [ActiveElement] {
+        return activeElements.filter({ (activeElement) -> Bool in
+            switch (type, activeElement) {
+            case (.phone(_), .phone(_)):
+                return true
+            case (.email(_), .email(_)):
+                return true
+            case (.url(_, _), .url(_, _)):
+                return true
+            case (.mention(_), .mention(_)):
+                return true
+            case (.hashtag(_), .hashtag(_)):
+                return true
+            case (.address(_), .address(_)):
+                return true
+            case (.date(_), .date(_)):
+                return true
+            case (.custom(_), .custom(_)):
+                return true
+            default:
+                return false
+            }
+        })
+    }
+}

--- a/ActiveLabelTests/IntegrationTests/DateParsingIntegrationTests.swift
+++ b/ActiveLabelTests/IntegrationTests/DateParsingIntegrationTests.swift
@@ -1,0 +1,89 @@
+//
+//  DateParsingTests.swift
+//  ActiveLabelTests
+//
+//  Created by Alex Bush | Upkeep on 6/29/21.
+//  Copyright © 2021 Optonaut. All rights reserved.
+//
+
+import XCTest
+@testable import ActiveLabel
+
+final class DateParsingIntegrationTests: BaseIntegrationTestCase {
+    // MARK: - BEGIN Parsing
+    func testItShouldNotRecognizeAnyDatesInTextWithoutDates() {
+        // given
+        label.enabledTypes = [.date]
+        label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 0, "there shouldn't be any matches in a text that doesn't have any dates in it")
+    }
+    
+    func testItShouldFindTheRightMatchesInTextWithDates() {
+        // given
+        let dateMock1 = "2018-08-31"
+        let dateMock2 = "June 5th, 2021"
+        label.enabledTypes = [.date]
+        label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation \(dateMock1) ullamco laboris nisi ut aliquip ex ea commodo consequat. \(dateMock2) Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 2, "there should be matches in a text that contains dates")
+        let firstDateMatch = activeElements[0]
+        if case .date(let dateText) = firstDateMatch {
+            XCTAssertEqual(dateText, dateMock1)
+        } else {
+            XCTFail("first date should match")
+        }
+
+        let secondDateMatch = activeElements[1]
+        if case .date(let date) = secondDateMatch {
+            XCTAssertEqual(date, dateMock2)
+        } else {
+            XCTFail("second date should match")
+        }
+    }
+    
+    func testItShouldFindOnlyDateMatchesInATextWithEmailPhoneAndOtherElementsGivenDateAsTheOnlyEnabledType() {
+        // given
+        let dateMock1 = "2018-08-31"
+        let dateMock2 = "June 5th, 2021"
+        label.enabledTypes = [.date]
+        label.text = "Lorem ipsum dolor sit amet, @mention_of_something consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna \(dateMock1) aliqua. Ut #andahashtag enim ad minim veniam, quis email@somemail.com nostrud exercitation 202-555-0123 ullamco laboris nisi ut aliquip ex ea commodo consequat. +1-202-555-0116 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \(dateMock2) officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 2, "there should be matches in a text that contains dates")
+    }
+    
+    func testItShouldFindDateAndOtherMatchesInATextWithMultipleDifferentElements() {
+        // given
+        let dateMock1 = "2018-08-31"
+        label.enabledTypes = [.mention, .hashtag, .email, .phone, .address, .date]
+        label.text = "Lorem ipsum dolor sit amet, @mention_of_something consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut #andahashtag enim ad minim veniam, quis email@somemail.com nostrud exercitation 202-555-0123 ullamco laboris nisi ut aliquip ex ea commodo consequat. +1-202-555-0116 Duis aute irure dolor in reprehenderit \(dateMock1) in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 6, "there should be several different matches in a text that contains dates and other elements")
+        XCTAssertEqual(activeElements(perType: .mention("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .hashtag("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .email("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .phone("")).count, 2)
+        XCTAssertEqual(activeElements(perType: .date("")).count, 1)
+    }
+    // MARK: END Parsing -
+
+    // MARK: - BEGIN Handler Removal
+    func testItRemovesDateHandlerClosure() {
+        // given
+        label.handleDateTap(handler: {_ in })
+        XCTAssertNotNil(label.handleDateTap)
+        // when
+        label.removeHandle(for: .date)
+        // then
+        XCTAssertNil(label.dateTapHandler)
+    }
+    // MARK: END Handler Removal -
+}

--- a/ActiveLabelTests/IntegrationTests/PhoneParsingIntegrationTests.swift
+++ b/ActiveLabelTests/IntegrationTests/PhoneParsingIntegrationTests.swift
@@ -1,0 +1,85 @@
+//
+//  PhoneParsingActiveTypeTests.swift
+//  ActiveLabelTests
+//
+//  Created by Alex Bush | Upkeep on 6/29/21.
+//  Copyright © 2021 Upkeep. All rights reserved.
+//
+
+import XCTest
+@testable import ActiveLabel
+
+final class PhoneParsingIntegrationTests: BaseIntegrationTestCase {
+    // MARK: - BEGIN Parsing
+    func testItShouldNotRecognizeAnyPhoneNumbersInTextWithoutPhoneNumbers() {
+        // given
+        label.enabledTypes = [.phone]
+        label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 0, "there shouldn't be any matches in a text that doesn't have any phone numbers in it")
+    }
+    
+    func testItShouldFindTheRightMatchesInTextWithPhoneNumbers() {
+        // given
+        let phoneNumberMock1 = "202-555-0123"
+        let phoneNumberMock2 = "+1-202-555-0116"
+        label.enabledTypes = [.phone]
+        label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation \(phoneNumberMock1) ullamco laboris nisi ut aliquip ex ea commodo consequat. \(phoneNumberMock2) Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 2, "there should be matches in a text that contains phone numbers")
+        let firstPhoneMatch = activeElements[0]
+        if case .phone(let phoneNumberText) = firstPhoneMatch {
+            XCTAssertEqual(phoneNumberText, phoneNumberMock1)
+        } else {
+            XCTFail("first phone number should match")
+        }
+        
+        let secondPhoneMatch = activeElements[1]
+        if case .phone(let phoneNumberText) = secondPhoneMatch {
+            XCTAssertEqual(phoneNumberText, phoneNumberMock2)
+        } else {
+            XCTFail("second phone number should match")
+        }
+    }
+    
+    func testItShouldFindOnlyPhoneMatchesInATextWithEmailPhoneAndOtherElementsGivenPhoneAsTheOnlyEnabledType() {
+        // given
+        label.enabledTypes = [.phone]
+        label.text = "Lorem ipsum dolor sit amet, @mention_of_something consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut #andahashtag enim ad minim veniam, quis email@somemail.com nostrud exercitation 202-555-0123 ullamco laboris nisi ut aliquip ex ea commodo consequat. +1-202-555-0116 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 2, "there should be matches in a text that contains phone numbers")
+    }
+    
+    func testItShouldFindPhoneAndOtherMatchesInATextWithMultipleDifferentElements() {
+        // given
+        label.enabledTypes = [.mention, .hashtag, .email, .phone]
+        label.text = "Lorem ipsum dolor sit amet, @mention_of_something consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut #andahashtag enim ad minim veniam, quis email@somemail.com nostrud exercitation 202-555-0123 ullamco laboris nisi ut aliquip ex ea commodo consequat. +1-202-555-0116 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        // when
+        let numberOfRecognizedPatterns = activeElements.count
+        // then
+        XCTAssertEqual(numberOfRecognizedPatterns, 5, "there should be several different matches in a text that contains phone numbers and other elements")
+        XCTAssertEqual(activeElements(perType: .mention("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .hashtag("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .email("")).count, 1)
+        XCTAssertEqual(activeElements(perType: .phone("")).count, 2)
+    }
+    // MARK: END Parsing -
+
+    // MARK: - BEGIN Handler Removal
+    func testItRemovesPhoneHandlerClosure() {
+        // given
+        label.handlePhoneTap(handler: {_ in })
+        XCTAssertNotNil(label.handlePhoneTap)
+        // when
+        label.removeHandle(for: .phone)
+        // then
+        XCTAssertNil(label.phoneTapHandler)
+    }
+    // MARK: END Handler Removal -
+}

--- a/ActiveLabelTests/Mocks/MockActiveBuilder.swift
+++ b/ActiveLabelTests/Mocks/MockActiveBuilder.swift
@@ -1,0 +1,26 @@
+@testable import ActiveLabel
+
+final class MockActiveBuilder: ActiveBuilderInterface {
+    
+    private let activeBuilder: ActiveBuilderInterface
+    
+    init(activeBuilder: ActiveBuilderInterface = ActiveBuilder(regexParser: RegexParser())) {
+        self.activeBuilder = activeBuilder
+    }
+    
+    var createElementsCallCount = 0
+    func createElements(type: ActiveType, from text: String, range: NSRange, filterPredicate: ActiveFilterPredicate?) -> [ElementTuple] {
+        createElementsCallCount += 1
+        // TODO: add mock method handler
+        return activeBuilder.createElements(type: type, from: text, range: range, filterPredicate: filterPredicate)
+    }
+    
+    var createURLElementsCallCount = 0
+    func createURLElements(from text: String, range: NSRange, maximumLength: Int?) -> ([ElementTuple], String) {
+        createURLElementsCallCount += 1
+        // TODO: add mock method handler
+        return activeBuilder.createURLElements(from: text, range: range, maximumLength: maximumLength)
+    }
+    
+    
+}


### PR DESCRIPTION
This PR adds support for parsing phone numbers, dates, and addresses using `NSDataDetector` (a subclass of `NSRegularExpression`). 

`NSDataDetectors` are only used for parsing the new types of links and previous regex patterns were preserved for urls, mentions, etc.

This PR introduces refactoring of existing codebase around `RegexParser` and `ActiveBuilder` making them injectable objects for easier extensibility, modification, unit-testing, and general adherence to SOLID principles.

This PR also refactors the tests suite of this project and separates it into two: unit-testing cases, and integration testing cases. Integration testing cases are the tests for the entire system as a whole, i.e. how the actual `ActiveLabel` object instances behave given various text contents. And the unit-testing cases test the interaction and behavior between objects `ActiveLabel` is using via injected mocks.

 