### PR TITLE
Fix value of urlPattern in RegexParser

### DIFF
--- a/ActiveLabel.xcodeproj/project.pbxproj
+++ b/ActiveLabel.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		C1D15C791D7C9B610041D119 /* StringTrimExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D15C781D7C9B610041D119 /* StringTrimExtension.swift */; };
 		C1D15C7B1D7C9B7E0041D119 /* ActiveBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D15C7A1D7C9B7E0041D119 /* ActiveBuilder.swift */; };
 		C1E867D61C3D7AEA00FD687A /* RegexParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E867D51C3D7AEA00FD687A /* RegexParser.swift */; };
+		CE3BE93727F4AC84006A3145 /* RegexParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3BE93627F4AC84006A3145 /* RegexParserTest.swift */; };
 		E267FA251DB3A34900EEAC4C /* ActiveLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0249A21B9989B1005D8035 /* ActiveLabel.framework */; };
 		E267FA261DB3A34900EEAC4C /* ActiveLabel.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0249A21B9989B1005D8035 /* ActiveLabel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -74,6 +75,7 @@
 		C1D15C781D7C9B610041D119 /* StringTrimExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTrimExtension.swift; sourceTree = "<group>"; };
 		C1D15C7A1D7C9B7E0041D119 /* ActiveBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveBuilder.swift; sourceTree = "<group>"; };
 		C1E867D51C3D7AEA00FD687A /* RegexParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexParser.swift; sourceTree = "<group>"; };
+		CE3BE93627F4AC84006A3145 /* RegexParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexParserTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 			isa = PBXGroup;
 			children = (
 				8F0249B11B9989B1005D8035 /* ActiveTypeTests.swift */,
+				CE3BE93627F4AC84006A3145 /* RegexParserTest.swift */,
 				8F0249B31B9989B1005D8035 /* Info.plist */,
 			);
 			path = ActiveLabelTests;
@@ -317,6 +320,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE3BE93727F4AC84006A3145 /* RegexParserTest.swift in Sources */,
 				8F0249B21B9989B1005D8035 /* ActiveTypeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -13,7 +13,7 @@ struct RegexParser {
     static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"
     static let mentionPattern = "(?:^|\\s|$|[.])@[\\p{L}0-9_]*"
     static let emailPattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
-    static let urlPattern = "(http|https|ftp)\\://[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\\-\\._\\?\\,\'/\\\\+&amp;%\\$#\\=~])*"
+    static let urlPattern = "(https?://|www\\.|pic\\.)[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\\-\\._\\?\\,\'/\\\\+&amp;%\\$#\\=~])*"
 
     private static var cachedRegularExpressions: [String : NSRegularExpression] = [:]
 

--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -13,9 +13,7 @@ struct RegexParser {
     static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"
     static let mentionPattern = "(?:^|\\s|$|[.])@[\\p{L}0-9_]*"
     static let emailPattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
-    static let urlPattern = "(^|[\\s.:;?\\-\\]<\\(])" +
-        "((https?://|www\\.|pic\\.)[-\\w;/?:@&=+$\\|\\_.!~*\\|'()\\[\\]%#,☺]+[\\w/#](\\(\\))?)" +
-    "(?=$|[\\s',\\|\\(\\).:;?\\-\\[\\]>\\)])"
+    static let urlPattern = "(http|https|ftp)\\://[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\\-\\._\\?\\,\'/\\\\+&amp;%\\$#\\=~])*"
 
     private static var cachedRegularExpressions: [String : NSRegularExpression] = [:]
 

--- a/ActiveLabelTests/RegexParserTest.swift
+++ b/ActiveLabelTests/RegexParserTest.swift
@@ -1,0 +1,48 @@
+//
+//  RegexParserTest.swift
+//  ActiveLabelTests
+//
+//  Created by Steve Kim on 2022/03/31.
+//  Copyright © 2022 Optonaut. All rights reserved.
+//
+
+import XCTest
+@testable import ActiveLabel
+
+class RegexParserTest: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testGetElementsWithURLPattern() {
+        let strings = [
+            "http://www.google.com",
+            "https://www.google.com",
+            "www.google.com",
+            "https://www.google.com에서 확인",
+        ]
+        let elements = strings.compactMap {
+            RegexParser.getElements(from: $0, with: RegexParser.urlPattern, range: NSMakeRange(0, $0.count)).first
+        }
+
+        XCTAssertEqual(strings.count, elements.count)
+    }
+
+    func testRangeOfGetElementsWithURLPattern() {
+        let string = "https://www.google.com에서 확인"
+        let range = NSMakeRange(0, string.count)
+        let rangeOfFirstElement = RegexParser.getElements(from: string, with: RegexParser.urlPattern, range: range).first!.range
+        let startIndex = string.index(string.startIndex, offsetBy: rangeOfFirstElement.location)
+        let endIndex = string.index(string.startIndex, offsetBy: rangeOfFirstElement.location + rangeOfFirstElement.length)
+        let substring = string[startIndex..<endIndex]
+
+        XCTAssertEqual("https://www.google.com", substring)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed the problem that other string after url are recognized as url
- Add a file RegexParserTest.swift


### Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/471004/160880449-a8565a87-230d-479f-bc34-20b072b65a96.png" width="300" /> | <img src="https://user-images.githubusercontent.com/471004/160880459-a114d2b2-8307-41d0-9ca3-d1dd293a6abf.png" width="300" />