### PR TITLE
Added hyphen to hashtagPattern in RegexParser so that hashtags with hyphens are recognized

### DIFF
--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct RegexParser {
 
-    static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"
+    static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_-]*"
     static let mentionPattern = "(?:^|\\s|$|[.])@[\\p{L}0-9_]*"
     static let emailPattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
     static let urlPattern = "(^|[\\s.:;?\\-\\]<\\(])" +


### PR DESCRIPTION
Just added the hyphen character to the hashtagPattern regex in RegexParser so that it recognizes #hash-tags #with-hyphens :)